### PR TITLE
Replaced licence boiler plate for all cc and h files in our sources

### DIFF
--- a/bin/cc_and_h_licence_block.txt
+++ b/bin/cc_and_h_licence_block.txt
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/bin/minimal_mpi_test.cc
+++ b/bin/minimal_mpi_test.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/bin/minimal_mpi_variablenp_test.cc
+++ b/bin/minimal_mpi_variablenp_test.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/FAQ/broken_this_demo.cc
+++ b/demo_drivers/FAQ/broken_this_demo.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/FAQ/customising_output.cc
+++ b/demo_drivers/FAQ/customising_output.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/advection_diffusion/two_d_adv_diff_SUPG/two_d_adv_diff_SUPG.cc
+++ b/demo_drivers/advection_diffusion/two_d_adv_diff_SUPG/two_d_adv_diff_SUPG.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/advection_diffusion/two_d_adv_diff_adapt/two_d_adv_diff_adapt.cc
+++ b/demo_drivers/advection_diffusion/two_d_adv_diff_adapt/two_d_adv_diff_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/advection_diffusion/two_d_adv_diff_adapt/two_d_adv_diff_adapt2.cc
+++ b/demo_drivers/advection_diffusion/two_d_adv_diff_adapt/two_d_adv_diff_adapt2.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/advection_diffusion/two_d_adv_diff_flux_bc/two_d_adv_diff_flux_bc.cc
+++ b/demo_drivers/advection_diffusion/two_d_adv_diff_flux_bc/two_d_adv_diff_flux_bc.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/advection_diffusion/two_d_variable_diff/two_d_variable_diff_adapt.cc
+++ b/demo_drivers/advection_diffusion/two_d_variable_diff/two_d_variable_diff_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/all_foeppl_von_karman/axisym_displ_based_fvk.cc
+++ b/demo_drivers/all_foeppl_von_karman/axisym_displ_based_fvk.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1176 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-11 17:57:27 +0100 (Wed, 11 May 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/all_foeppl_von_karman/axisym_fvk.cc
+++ b/demo_drivers/all_foeppl_von_karman/axisym_fvk.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1176 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-11 17:57:27 +0100 (Wed, 11 May 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/all_foeppl_von_karman/circular_disk.cc
+++ b/demo_drivers/all_foeppl_von_karman/circular_disk.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1176 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-11 17:57:27 +0100 (Wed, 11 May 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/all_foeppl_von_karman/displacement_based_circular_disk.cc
+++ b/demo_drivers/all_foeppl_von_karman/displacement_based_circular_disk.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1176 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-11 17:57:27 +0100 (Wed, 11 May 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_advection_diffusion/pipe/pipe.cc
+++ b/demo_drivers/axisym_advection_diffusion/pipe/pipe.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_advection_diffusion/pipe/pipe_variable_diff.cc
+++ b/demo_drivers/axisym_advection_diffusion/pipe/pipe_variable_diff.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_displ_based_foeppl_von_karman/axisym_displ_based_fvk.cc
+++ b/demo_drivers/axisym_displ_based_foeppl_von_karman/axisym_displ_based_fvk.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_foeppl_von_karman/axisym_fvk.cc
+++ b/demo_drivers/axisym_foeppl_von_karman/axisym_fvk.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_linear_elasticity/cylinder/cylinder.cc
+++ b/demo_drivers/axisym_linear_elasticity/cylinder/cylinder.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/axi_static_cap/axi_static_cap.cc
+++ b/demo_drivers/axisym_navier_stokes/axi_static_cap/axi_static_cap.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/counter_rotating_disks/counter_rotating_disks.cc
+++ b/demo_drivers/axisym_navier_stokes/counter_rotating_disks/counter_rotating_disks.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/counter_rotating_disks/counter_rotating_disks_ref.cc
+++ b/demo_drivers/axisym_navier_stokes/counter_rotating_disks/counter_rotating_disks_ref.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/counter_rotating_disks/linearised_axisym_navier_stokes_elements.cc
+++ b/demo_drivers/axisym_navier_stokes/counter_rotating_disks/linearised_axisym_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/counter_rotating_disks/linearised_axisym_navier_stokes_elements.h
+++ b/demo_drivers/axisym_navier_stokes/counter_rotating_disks/linearised_axisym_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/counter_rotating_disks/multi_domain_linearised_axisym_navier_stokes_elements.h
+++ b/demo_drivers/axisym_navier_stokes/counter_rotating_disks/multi_domain_linearised_axisym_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/counter_rotating_disks/refineable_linearised_axisym_navier_stokes_elements.cc
+++ b/demo_drivers/axisym_navier_stokes/counter_rotating_disks/refineable_linearised_axisym_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/counter_rotating_disks/refineable_linearised_axisym_navier_stokes_elements.h
+++ b/demo_drivers/axisym_navier_stokes/counter_rotating_disks/refineable_linearised_axisym_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/fibre/fibre.cc
+++ b/demo_drivers/axisym_navier_stokes/fibre/fibre.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/rayleigh_instability/rayleigh_instability.cc
+++ b/demo_drivers/axisym_navier_stokes/rayleigh_instability/rayleigh_instability.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/rotating_ends/rotating_ends.cc
+++ b/demo_drivers/axisym_navier_stokes/rotating_ends/rotating_ends.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/single_layer_free_surface_axisym/single_layer_free_surface_axisym.cc
+++ b/demo_drivers/axisym_navier_stokes/single_layer_free_surface_axisym/single_layer_free_surface_axisym.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/spin_up/spin_up.cc
+++ b/demo_drivers/axisym_navier_stokes/spin_up/spin_up.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/torus/torus.cc
+++ b/demo_drivers/axisym_navier_stokes/torus/torus.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/two_fluid_spherical_cap/two_fluid_spherical_cap.cc
+++ b/demo_drivers/axisym_navier_stokes/two_fluid_spherical_cap/two_fluid_spherical_cap.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/two_layer_interface_axisym/elastic_two_layer_interface_axisym.cc
+++ b/demo_drivers/axisym_navier_stokes/two_layer_interface_axisym/elastic_two_layer_interface_axisym.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/two_layer_interface_axisym/spine_two_layer_interface_axisym.cc
+++ b/demo_drivers/axisym_navier_stokes/two_layer_interface_axisym/spine_two_layer_interface_axisym.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/unstructured_torus/pressure_driven_torus.cc
+++ b/demo_drivers/axisym_navier_stokes/unstructured_torus/pressure_driven_torus.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_navier_stokes/unstructured_torus/unstructured_torus.cc
+++ b/demo_drivers/axisym_navier_stokes/unstructured_torus/unstructured_torus.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/axisym_poroelasticity/unstructured_two_d_curved/unstructured_two_d_curved.cc
+++ b/demo_drivers/axisym_poroelasticity/unstructured_two_d_curved/unstructured_two_d_curved.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/beam/steady_ring/steady_ring.cc
+++ b/demo_drivers/beam/steady_ring/steady_ring.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/beam/steady_third_ring/steady_third_ring.cc
+++ b/demo_drivers/beam/steady_third_ring/steady_third_ring.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/beam/tensioned_string/tensioned_string.cc
+++ b/demo_drivers/beam/tensioned_string/tensioned_string.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/beam/unsteady_ring/lin_unsteady_ring.cc
+++ b/demo_drivers/beam/unsteady_ring/lin_unsteady_ring.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/beam/unsteady_ring/unsteady_ring.cc
+++ b/demo_drivers/beam/unsteady_ring/unsteady_ring.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/bifurcation_tracking/adaptive_hopf.cc
+++ b/demo_drivers/bifurcation_tracking/adaptive_hopf.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/bifurcation_tracking/adaptive_hopf_with_separate_meshes.cc
+++ b/demo_drivers/bifurcation_tracking/adaptive_hopf_with_separate_meshes.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/bifurcation_tracking/adaptive_pitchfork.cc
+++ b/demo_drivers/bifurcation_tracking/adaptive_pitchfork.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/bifurcation_tracking/fold.cc
+++ b/demo_drivers/bifurcation_tracking/fold.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/bifurcation_tracking/hopf.cc
+++ b/demo_drivers/bifurcation_tracking/hopf.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/bifurcation_tracking/periodic_orbit.cc
+++ b/demo_drivers/bifurcation_tracking/periodic_orbit.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/bifurcation_tracking/pitchfork.cc
+++ b/demo_drivers/bifurcation_tracking/pitchfork.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/bifurcation_tracking/track_pitch.cc
+++ b/demo_drivers/bifurcation_tracking/track_pitch.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/biharmonic/structured_2d_biharmonic/structured_2d_biharmonic_bellelement.cc
+++ b/demo_drivers/biharmonic/structured_2d_biharmonic/structured_2d_biharmonic_bellelement.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/biharmonic/two_d_biharmonic/two_d_biharmonic.cc
+++ b/demo_drivers/biharmonic/two_d_biharmonic/two_d_biharmonic.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/biharmonic/unstructured_2d_biharmonic/unstructured_2d_biharmonic_bellelement.cc
+++ b/demo_drivers/biharmonic/unstructured_2d_biharmonic/unstructured_2d_biharmonic_bellelement.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/biharmonic/unstructured_2d_biharmonic/unstructured_2d_biharmonic_curvedelement.cc
+++ b/demo_drivers/biharmonic/unstructured_2d_biharmonic/unstructured_2d_biharmonic_curvedelement.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/darcy/unstructured_two_d_circle/unstructured_two_d_circle.cc
+++ b/demo_drivers/darcy/unstructured_two_d_circle/unstructured_two_d_circle.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/eigenproblems/harmonic/complex_harmonic.cc
+++ b/demo_drivers/eigenproblems/harmonic/complex_harmonic.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/eigenproblems/harmonic/harmonic.cc
+++ b/demo_drivers/eigenproblems/harmonic/harmonic.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/eigenproblems/orr_sommerfeld/orr_sommerfeld.cc
+++ b/demo_drivers/eigenproblems/orr_sommerfeld/orr_sommerfeld.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/extrude_quad_mesh_to_cube_mesh/extrude_triangle_generated_mesh.cc
+++ b/demo_drivers/extrude_quad_mesh_to_cube_mesh/extrude_triangle_generated_mesh.cc
@@ -1,29 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//           Version 0.90. August 3, 2009.
-//LIC//
-//LIC// Copyright (C) 2006-2009 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Driver for 2D moving block
 

--- a/demo_drivers/extrude_quad_mesh_to_cube_mesh/extrude_with_macro_element_representation.cc
+++ b/demo_drivers/extrude_quad_mesh_to_cube_mesh/extrude_with_macro_element_representation.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1162 $
-//LIC//
-//LIC// $LastChangedDate: 2016-04-18 13:27:54 +0100 (Mon, 18 Apr 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Generic oomph-lib stuff
 #include "generic.h"

--- a/demo_drivers/flux_transport/advection/one_d_advection.cc
+++ b/demo_drivers/flux_transport/advection/one_d_advection.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/flux_transport/advection/two_d_advection.cc
+++ b/demo_drivers/flux_transport/advection/two_d_advection.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/flux_transport/euler/couette.cc
+++ b/demo_drivers/flux_transport/euler/couette.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/flux_transport/euler/ff_step.cc
+++ b/demo_drivers/flux_transport/euler/ff_step.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/flux_transport/euler/one_d_euler.cc
+++ b/demo_drivers/flux_transport/euler/one_d_euler.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/flux_transport/euler/ramp.cc
+++ b/demo_drivers/flux_transport/euler/ramp.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/flux_transport/euler/two_d_euler.cc
+++ b/demo_drivers/flux_transport/euler/two_d_euler.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/foeppl_von_karman/circular_disk/circular_disk.cc
+++ b/demo_drivers/foeppl_von_karman/circular_disk/circular_disk.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/fourier_decomposed_helmholtz/sphere_scattering/sphere_scattering.cc
+++ b/demo_drivers/fourier_decomposed_helmholtz/sphere_scattering/sphere_scattering.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/fourier_decomposed_helmholtz/sphere_scattering/unstructured_sphere_scattering.cc
+++ b/demo_drivers/fourier_decomposed_helmholtz/sphere_scattering/unstructured_sphere_scattering.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/generalised_newtonian_axisym_navier_stokes/axisym_vibrating_shell/axisym_vibrating_shell_non_newtonian.cc
+++ b/demo_drivers/generalised_newtonian_axisym_navier_stokes/axisym_vibrating_shell/axisym_vibrating_shell_non_newtonian.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/generalised_newtonian_axisym_navier_stokes/axisym_vibrating_shell/overloaded_element_body.h
+++ b/demo_drivers/generalised_newtonian_axisym_navier_stokes/axisym_vibrating_shell/overloaded_element_body.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/generalised_newtonian_navier_stokes/vibrating_shell/overloaded_cartesian_element_body.h
+++ b/demo_drivers/generalised_newtonian_navier_stokes/vibrating_shell/overloaded_cartesian_element_body.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/generalised_newtonian_navier_stokes/vibrating_shell/vibrating_shell_non_newtonian.cc
+++ b/demo_drivers/generalised_newtonian_navier_stokes/vibrating_shell/vibrating_shell_non_newtonian.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/circular_boulder_melt.cc
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/circular_boulder_melt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/circular_boulder_solar_radiation.cc
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/circular_boulder_solar_radiation.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/contact_elements.h
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/contact_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/heat_transfer_and_melt_elements.h
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/heat_transfer_and_melt_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/heated_linear_solid_contact_with_gravity.cc
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/heated_linear_solid_contact_with_gravity.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/linear_solid_contact_with_gravity.cc
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/linear_solid_contact_with_gravity.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/melt.cc
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/melt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/pretend_melt.cc
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/pretend_melt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/solid_contact.cc
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/solid_contact.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/solid_contact_with_gravity.cc
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/solid_contact_with_gravity.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/spring_contact.cc
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/spring_contact.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/spring_contact2.cc
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/spring_contact2.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/stefan_boltzmann.cc
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/stefan_boltzmann.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/stefan_boltzmann_melt.cc
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/stefan_boltzmann_melt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/temporary_stefan_boltzmann_elements.h
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/temporary_stefan_boltzmann_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/two_d_unsteady_heat.cc
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/two_d_unsteady_heat.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/unsteady_heat_flux_pseudo_melt_elements.h
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/unsteady_heat_flux_pseudo_melt_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/helmholtz/point_source/helmholtz_point_source.cc
+++ b/demo_drivers/helmholtz/point_source/helmholtz_point_source.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/helmholtz/scattering/scattering.cc
+++ b/demo_drivers/helmholtz/scattering/scattering.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/helmholtz/scattering/unstructured_scattering.cc
+++ b/demo_drivers/helmholtz/scattering/unstructured_scattering.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/homogenisation/two_dim/Thomo_lin_elasticity_elements.cc
+++ b/demo_drivers/homogenisation/two_dim/Thomo_lin_elasticity_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/homogenisation/two_dim/Thomo_lin_elasticity_elements.h
+++ b/demo_drivers/homogenisation/two_dim/Thomo_lin_elasticity_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/homogenisation/two_dim/homo_lin_elasticity_elements.cc
+++ b/demo_drivers/homogenisation/two_dim/homo_lin_elasticity_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/homogenisation/two_dim/homo_lin_elasticity_elements.h
+++ b/demo_drivers/homogenisation/two_dim/homo_lin_elasticity_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/homogenisation/two_dim/two_dim.cc
+++ b/demo_drivers/homogenisation/two_dim/two_dim.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/homogenisation/two_dim/two_dim_hex.cc
+++ b/demo_drivers/homogenisation/two_dim/two_dim_hex.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/acoustic_fsi/acoustic_fsi.cc
+++ b/demo_drivers/interaction/acoustic_fsi/acoustic_fsi.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/acoustic_fsi/unstructured_acoustic_fsi.cc
+++ b/demo_drivers/interaction/acoustic_fsi/unstructured_acoustic_fsi.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/elastic_bretherton/elastic_bretherton.cc
+++ b/demo_drivers/interaction/elastic_bretherton/elastic_bretherton.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fourier_decomposed_acoustic_fsi/fourier_decomposed_acoustic_fsi.cc
+++ b/demo_drivers/interaction/fourier_decomposed_acoustic_fsi/fourier_decomposed_acoustic_fsi.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fourier_decomposed_acoustic_fsi/unstructured_fourier_decomposed_acoustic_fsi.cc
+++ b/demo_drivers/interaction/fourier_decomposed_acoustic_fsi/unstructured_fourier_decomposed_acoustic_fsi.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/free_boundary_poisson/algebraic_free_boundary_poisson.cc
+++ b/demo_drivers/interaction/free_boundary_poisson/algebraic_free_boundary_poisson.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/free_boundary_poisson/circle.cc
+++ b/demo_drivers/interaction/free_boundary_poisson/circle.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/free_boundary_poisson/circle.h
+++ b/demo_drivers/interaction/free_boundary_poisson/circle.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/free_boundary_poisson/circle_as_generalised_element.h
+++ b/demo_drivers/interaction/free_boundary_poisson/circle_as_generalised_element.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/free_boundary_poisson/doc_sparse_macro_node_update.cc
+++ b/demo_drivers/interaction/free_boundary_poisson/doc_sparse_macro_node_update.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/free_boundary_poisson/elastic_mesh_update.cc
+++ b/demo_drivers/interaction/free_boundary_poisson/elastic_mesh_update.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/free_boundary_poisson/elastic_poisson.cc
+++ b/demo_drivers/interaction/free_boundary_poisson/elastic_poisson.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/free_boundary_poisson/geom_object_element.cc
+++ b/demo_drivers/interaction/free_boundary_poisson/geom_object_element.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/free_boundary_poisson/macro_element_free_boundary_poisson.cc
+++ b/demo_drivers/interaction/free_boundary_poisson/macro_element_free_boundary_poisson.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/free_boundary_poisson/macro_element_free_boundary_poisson_non_ref.cc
+++ b/demo_drivers/interaction/free_boundary_poisson/macro_element_free_boundary_poisson_non_ref.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/free_boundary_poisson/old_for_doc.cc
+++ b/demo_drivers/interaction/free_boundary_poisson/old_for_doc.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fsi_channel_seg_and_precond/fsi_chan_precond_driver.cc
+++ b/demo_drivers/interaction/fsi_channel_seg_and_precond/fsi_chan_precond_driver.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fsi_channel_seg_and_precond/fsi_chan_problem.h
+++ b/demo_drivers/interaction/fsi_channel_seg_and_precond/fsi_chan_problem.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fsi_channel_seg_and_precond/fsi_chan_seg_driver.cc
+++ b/demo_drivers/interaction/fsi_channel_seg_and_precond/fsi_chan_seg_driver.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fsi_channel_seg_and_precond/simple_segregated_driver.cc
+++ b/demo_drivers/interaction/fsi_channel_seg_and_precond/simple_segregated_driver.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fsi_channel_with_leaflet/fsi_channel_with_leaflet.cc
+++ b/demo_drivers/interaction/fsi_channel_with_leaflet/fsi_channel_with_leaflet.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fsi_collapsible_channel/fsi_collapsible_channel.cc
+++ b/demo_drivers/interaction/fsi_collapsible_channel/fsi_collapsible_channel.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fsi_collapsible_channel/fsi_collapsible_channel_adapt.cc
+++ b/demo_drivers/interaction/fsi_collapsible_channel/fsi_collapsible_channel_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fsi_collapsible_channel/fsi_pseudo_solid_collapsible_channel.cc
+++ b/demo_drivers/interaction/fsi_collapsible_channel/fsi_pseudo_solid_collapsible_channel.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fsi_collapsible_channel/fsi_pseudo_solid_collapsible_channel_adapt.cc
+++ b/demo_drivers/interaction/fsi_collapsible_channel/fsi_pseudo_solid_collapsible_channel_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fsi_driven_cavity/fsi_driven_cavity_driver.cc
+++ b/demo_drivers/interaction/fsi_driven_cavity/fsi_driven_cavity_driver.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fsi_driven_cavity/fsi_driven_cavity_problem.h
+++ b/demo_drivers/interaction/fsi_driven_cavity/fsi_driven_cavity_problem.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fsi_driven_cavity/fsi_driven_cavity_segregated_driver.cc
+++ b/demo_drivers/interaction/fsi_driven_cavity/fsi_driven_cavity_segregated_driver.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fsi_osc_ring/fsi_osc_ring.cc
+++ b/demo_drivers/interaction/fsi_osc_ring/fsi_osc_ring.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fsi_osc_ring/fsi_osc_ring_compare_jacs.cc
+++ b/demo_drivers/interaction/fsi_osc_ring/fsi_osc_ring_compare_jacs.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fsi_osc_ring/osc_ring_alg.cc
+++ b/demo_drivers/interaction/fsi_osc_ring/osc_ring_alg.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fsi_osc_ring/osc_ring_macro.cc
+++ b/demo_drivers/interaction/fsi_osc_ring/osc_ring_macro.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/fsi_osc_ring/osc_ring_sarah_asymptotics.h
+++ b/demo_drivers/interaction/fsi_osc_ring/osc_ring_sarah_asymptotics.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/linearised_fsi_pulsewave/linearised_fsi_pulsewave.cc
+++ b/demo_drivers/interaction/linearised_fsi_pulsewave/linearised_fsi_pulsewave.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/linearised_poroelastic_fsi_pulsewave/linearised_poroelastic_fsi_pulsewave.cc
+++ b/demo_drivers/interaction/linearised_poroelastic_fsi_pulsewave/linearised_poroelastic_fsi_pulsewave.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/pseudo_solid_collapsible_tube/pseudo_solid_collapsible_tube.cc
+++ b/demo_drivers/interaction/pseudo_solid_collapsible_tube/pseudo_solid_collapsible_tube.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/pseudo_solid_collapsible_tube/pseudo_solid_collapsible_tube_work.cc
+++ b/demo_drivers/interaction/pseudo_solid_collapsible_tube/pseudo_solid_collapsible_tube_work.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/pseudo_solid_fsi_channel_with_leaflet/fsi_channel_with_leaflet_precond.cc
+++ b/demo_drivers/interaction/pseudo_solid_fsi_channel_with_leaflet/fsi_channel_with_leaflet_precond.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/turek_flag/turek_flag.cc
+++ b/demo_drivers/interaction/turek_flag/turek_flag.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/unsteady_vmtk_fsi/unsteady_vmtk_fsi.cc
+++ b/demo_drivers/interaction/unsteady_vmtk_fsi/unsteady_vmtk_fsi.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/unstructured_adaptive_fsi/unstructured_adaptive_2d_fsi.cc
+++ b/demo_drivers/interaction/unstructured_adaptive_fsi/unstructured_adaptive_2d_fsi.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/unstructured_fsi/unstructured_two_d_fsi.cc
+++ b/demo_drivers/interaction/unstructured_fsi/unstructured_two_d_fsi.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/unstructured_three_d_fsi/unstructured_three_d_fsi.cc
+++ b/demo_drivers/interaction/unstructured_three_d_fsi/unstructured_three_d_fsi.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/interaction/vmtk_fsi/vmtk_fsi.cc
+++ b/demo_drivers/interaction/vmtk_fsi/vmtk_fsi.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_elasticity/periodic_load/periodic_load.cc
+++ b/demo_drivers/linear_elasticity/periodic_load/periodic_load.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_elasticity/periodic_load/refineable_periodic_load.cc
+++ b/demo_drivers/linear_elasticity/periodic_load/refineable_periodic_load.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_solvers/HypreSolver_test.cc
+++ b/demo_drivers/linear_solvers/HypreSolver_test.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_solvers/TrilinosSolver_test.cc
+++ b/demo_drivers/linear_solvers/TrilinosSolver_test.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_solvers/adv_diff_iterative_linear_solver_tester.cc
+++ b/demo_drivers/linear_solvers/adv_diff_iterative_linear_solver_tester.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_solvers/direct_solver_test.cc
+++ b/demo_drivers/linear_solvers/direct_solver_test.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_solvers/driven_cavity.cc
+++ b/demo_drivers/linear_solvers/driven_cavity.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_solvers/driven_cavity_with_simple_lsc_preconditioner.cc
+++ b/demo_drivers/linear_solvers/driven_cavity_with_simple_lsc_preconditioner.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_solvers/multi_poisson_block_preconditioners.h
+++ b/demo_drivers/linear_solvers/multi_poisson_block_preconditioners.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_solvers/multi_poisson_elements.h
+++ b/demo_drivers/linear_solvers/multi_poisson_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_solvers/simple_block_preconditioners.h
+++ b/demo_drivers/linear_solvers/simple_block_preconditioners.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_solvers/two_d_linear_elasticity_with_simple_block_diagonal_preconditioner.cc
+++ b/demo_drivers/linear_solvers/two_d_linear_elasticity_with_simple_block_diagonal_preconditioner.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_solvers/two_d_multi_poisson.cc
+++ b/demo_drivers/linear_solvers/two_d_multi_poisson.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_solvers/two_d_poisson_cg.cc
+++ b/demo_drivers/linear_solvers/two_d_poisson_cg.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_solvers/two_d_poisson_dense_lu.cc
+++ b/demo_drivers/linear_solvers/two_d_poisson_dense_lu.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_wave/two_d_linear_wave/two_d_linear_wave.cc
+++ b/demo_drivers/linear_wave/two_d_linear_wave/two_d_linear_wave.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_wave/two_d_linear_wave/two_d_linear_wave_flux.cc
+++ b/demo_drivers/linear_wave/two_d_linear_wave/two_d_linear_wave_flux.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linear_wave/two_d_linear_wave_adapt/two_d_linear_wave_adapt.cc
+++ b/demo_drivers/linear_wave/two_d_linear_wave_adapt/two_d_linear_wave_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linearised_axisym_navier_stokes/counter_rotating_disks/counter_rotating_disks.cc
+++ b/demo_drivers/linearised_axisym_navier_stokes/counter_rotating_disks/counter_rotating_disks.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linearised_axisym_navier_stokes/counter_rotating_disks/counter_rotating_disks_ref.cc
+++ b/demo_drivers/linearised_axisym_navier_stokes/counter_rotating_disks/counter_rotating_disks_ref.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linearised_axisym_navier_stokes/self_starting_BDF2_timestepper.h
+++ b/demo_drivers/linearised_axisym_navier_stokes/self_starting_BDF2_timestepper.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linearised_axisym_navier_stokes/time_periodic_taylor_couette/time_periodic_taylor_couette.cc
+++ b/demo_drivers/linearised_axisym_navier_stokes/time_periodic_taylor_couette/time_periodic_taylor_couette.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/linearised_axisym_navier_stokes_elements.cc
+++ b/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/linearised_axisym_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/linearised_axisym_navier_stokes_elements.h
+++ b/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/linearised_axisym_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/linearised_axisymmetric_fluid_interface_elements.cc
+++ b/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/linearised_axisymmetric_fluid_interface_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/linearised_axisymmetric_fluid_interface_elements.h
+++ b/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/linearised_axisymmetric_fluid_interface_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/multi_domain_linearised_axisym_navier_stokes_elements.h
+++ b/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/multi_domain_linearised_axisym_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/perturbed_spines.cc
+++ b/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/perturbed_spines.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/perturbed_spines.h
+++ b/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/perturbed_spines.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/two_layer_interface_nonaxisym_perturbations.cc
+++ b/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/two_layer_interface_nonaxisym_perturbations.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/two_layer_perturbed_spine_mesh.template.cc
+++ b/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/two_layer_perturbed_spine_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/two_layer_perturbed_spine_mesh.template.h
+++ b/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/two_layer_perturbed_spine_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/linking/demo_code.cc
+++ b/demo_drivers/linking/demo_code.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/adaptive_tet_meshes/curved_facet_bounded_tetmesh.cc
+++ b/demo_drivers/meshing/adaptive_tet_meshes/curved_facet_bounded_tetmesh.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1307 $
-//LIC//
-//LIC// $LastChangedDate: 2018-01-18 11:30:14 +0000 (Thu, 18 Jan 2018) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/adaptive_tet_meshes/geom_obj_with_boundary.cc
+++ b/demo_drivers/meshing/adaptive_tet_meshes/geom_obj_with_boundary.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1307 $
-//LIC//
-//LIC// $LastChangedDate: 2018-01-18 11:30:14 +0000 (Thu, 18 Jan 2018) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/adaptive_tet_meshes/planar_facet_bounded_tetmesh.cc
+++ b/demo_drivers/meshing/adaptive_tet_meshes/planar_facet_bounded_tetmesh.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1307 $
-//LIC//
-//LIC// $LastChangedDate: 2018-01-18 11:30:14 +0000 (Thu, 18 Jan 2018) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/adaptive_tet_meshes/tetmesh_faceted_surfaces.h
+++ b/demo_drivers/meshing/adaptive_tet_meshes/tetmesh_faceted_surfaces.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1297 $
-//LIC//
-//LIC// $LastChangedDate: 2017-08-21 13:56:24 +0100 (Mon, 21 Aug 2017) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/mesh_from_geompack/convert_geom_file.cc
+++ b/demo_drivers/meshing/mesh_from_geompack/convert_geom_file.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/mesh_from_geompack/mesh_from_geompack_poisson.cc
+++ b/demo_drivers/meshing/mesh_from_geompack/mesh_from_geompack_poisson.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/mesh_from_inline_triangle/mesh_from_inline_triangle.cc
+++ b/demo_drivers/meshing/mesh_from_inline_triangle/mesh_from_inline_triangle.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/mesh_from_inline_triangle/mesh_from_inline_triangle_no_adapt.cc
+++ b/demo_drivers/meshing/mesh_from_inline_triangle/mesh_from_inline_triangle_no_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/mesh_from_inline_triangle_internal_boundaries/mesh_from_inline_triangle_internal_boundaries.cc
+++ b/demo_drivers/meshing/mesh_from_inline_triangle_internal_boundaries/mesh_from_inline_triangle_internal_boundaries.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/mesh_from_inline_triangle_internal_boundaries/mesh_from_inline_triangle_internal_boundaries_extra.cc
+++ b/demo_drivers/meshing/mesh_from_inline_triangle_internal_boundaries/mesh_from_inline_triangle_internal_boundaries_extra.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/mesh_from_tetgen/mesh_from_tetgen_navier_stokes.cc
+++ b/demo_drivers/meshing/mesh_from_tetgen/mesh_from_tetgen_navier_stokes.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/mesh_from_tetgen/mesh_from_tetgen_poisson.cc
+++ b/demo_drivers/meshing/mesh_from_tetgen/mesh_from_tetgen_poisson.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/mesh_from_triangle/mesh_from_triangle_navier_stokes.cc
+++ b/demo_drivers/meshing/mesh_from_triangle/mesh_from_triangle_navier_stokes.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/mesh_from_triangle/mesh_from_triangle_poisson.cc
+++ b/demo_drivers/meshing/mesh_from_triangle/mesh_from_triangle_poisson.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/mesh_from_vmtk/create_fluid_and_solid_surface_mesh_from_fluid_xda_mesh.cc
+++ b/demo_drivers/meshing/mesh_from_vmtk/create_fluid_and_solid_surface_mesh_from_fluid_xda_mesh.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/mesh_from_xfig_triangle/fig2poly.cc
+++ b/demo_drivers/meshing/mesh_from_xfig_triangle/fig2poly.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/mesh_from_xfig_triangle/mesh_from_xfig_navier_stokes.cc
+++ b/demo_drivers/meshing/mesh_from_xfig_triangle/mesh_from_xfig_navier_stokes.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/mesh_from_xfig_triangle/mesh_from_xfig_poisson.cc
+++ b/demo_drivers/meshing/mesh_from_xfig_triangle/mesh_from_xfig_poisson.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/quad_from_triangle_mesh/adaptive_moving_block_navier_stokes.cc
+++ b/demo_drivers/meshing/quad_from_triangle_mesh/adaptive_moving_block_navier_stokes.cc
@@ -3,9 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//           Version 0.90. August 3, 2009.
-//LIC// 
-//LIC// Copyright (C) 2006-2009 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/quad_from_triangle_mesh/adaptive_unstructured_scattering_quad.cc
+++ b/demo_drivers/meshing/quad_from_triangle_mesh/adaptive_unstructured_scattering_quad.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/quad_from_triangle_mesh/adaptive_unstructured_two_d_solid.cc
+++ b/demo_drivers/meshing/quad_from_triangle_mesh/adaptive_unstructured_two_d_solid.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1132 $
-//LIC//
-//LIC// $LastChangedDate: 2016-02-23 05:43:26 +0000 (Tue, 23 Feb 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/quad_from_triangle_mesh/unstructured_two_d_solid.cc
+++ b/demo_drivers/meshing/quad_from_triangle_mesh/unstructured_two_d_solid.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/quadratic_vmtk_tetgen/snap_mesh.cc
+++ b/demo_drivers/meshing/quadratic_vmtk_tetgen/snap_mesh.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/meshing/quadratic_vmtk_tetgen/xda_to_poly_fsi.cc
+++ b/demo_drivers/meshing/quadratic_vmtk_tetgen/xda_to_poly_fsi.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/adaptive_driven_cavity/adaptive_driven_cavity.cc
+++ b/demo_drivers/mpi/distribution/adaptive_driven_cavity/adaptive_driven_cavity.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/adaptive_driven_cavity/adaptive_driven_cavity_load_balance.cc
+++ b/demo_drivers/mpi/distribution/adaptive_driven_cavity/adaptive_driven_cavity_load_balance.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/airy_cantilever/airy_cantilever2.cc
+++ b/demo_drivers/mpi/distribution/airy_cantilever/airy_cantilever2.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/bifurcation_tracking/pitchfork.cc
+++ b/demo_drivers/mpi/distribution/bifurcation_tracking/pitchfork.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/bifurcation_tracking/track_pitch.cc
+++ b/demo_drivers/mpi/distribution/bifurcation_tracking/track_pitch.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/circular_driven_cavity/circular_driven_cavity.cc
+++ b/demo_drivers/mpi/distribution/circular_driven_cavity/circular_driven_cavity.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/clamped_shell/clamped_shell_with_arclength_cont.cc
+++ b/demo_drivers/mpi/distribution/clamped_shell/clamped_shell_with_arclength_cont.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/eigenproblem/harmonic.cc
+++ b/demo_drivers/mpi/distribution/eigenproblem/harmonic.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/fish_poisson/fish_poisson.cc
+++ b/demo_drivers/mpi/distribution/fish_poisson/fish_poisson.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/hanging_node_reconciliation/adaptive_driven_cavity.cc
+++ b/demo_drivers/mpi/distribution/hanging_node_reconciliation/adaptive_driven_cavity.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/hanging_node_reconciliation/hp_adaptive_driven_cavity.cc
+++ b/demo_drivers/mpi/distribution/hanging_node_reconciliation/hp_adaptive_driven_cavity.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/hp_adaptive_driven_cavity/hp_adaptive_driven_cavity.cc
+++ b/demo_drivers/mpi/distribution/hp_adaptive_driven_cavity/hp_adaptive_driven_cavity.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/hp_adaptive_poisson/two_d_poisson_hp_adapt.cc
+++ b/demo_drivers/mpi/distribution/hp_adaptive_poisson/two_d_poisson_hp_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/prescribed_displ_lagr_mult/prescribed_displ_lagr_mult.cc
+++ b/demo_drivers/mpi/distribution/prescribed_displ_lagr_mult/prescribed_displ_lagr_mult.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/prescribed_displ_lagr_mult/resize_hanging_node_tester.cc
+++ b/demo_drivers/mpi/distribution/prescribed_displ_lagr_mult/resize_hanging_node_tester.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/restart/two_d_unsteady_heat_2adapt_load_balance.cc
+++ b/demo_drivers/mpi/distribution/restart/two_d_unsteady_heat_2adapt_load_balance.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/three_d_cantilever/three_d_cantilever.cc
+++ b/demo_drivers/mpi/distribution/three_d_cantilever/three_d_cantilever.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/three_d_entry_flow/three_d_entry_flow.cc
+++ b/demo_drivers/mpi/distribution/three_d_entry_flow/three_d_entry_flow.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/three_d_prescribed_displ_lagr_mult/three_d_prescribed_displ_lagr_mult.cc
+++ b/demo_drivers/mpi/distribution/three_d_prescribed_displ_lagr_mult/three_d_prescribed_displ_lagr_mult.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/two_d_poisson_flux_bc_adapt/two_d_poisson_flux_bc_adapt.cc
+++ b/demo_drivers/mpi/distribution/two_d_poisson_flux_bc_adapt/two_d_poisson_flux_bc_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/two_d_unstructured_adaptive_poisson/two_d_parallel_unstructured_adaptive_poisson.cc
+++ b/demo_drivers/mpi/distribution/two_d_unstructured_adaptive_poisson/two_d_parallel_unstructured_adaptive_poisson.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/two_d_unstructured_adaptive_poisson/unstructured_adaptive_mesh_two_outer_boundaries.cc
+++ b/demo_drivers/mpi/distribution/two_d_unstructured_adaptive_poisson/unstructured_adaptive_mesh_two_outer_boundaries.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/distribution/two_d_unstructured_adaptive_poisson/unstructured_adaptive_mesh_two_outer_boundaries_crossed.cc
+++ b/demo_drivers/mpi/distribution/two_d_unstructured_adaptive_poisson/unstructured_adaptive_mesh_two_outer_boundaries_crossed.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/multi_domain/boussinesq_convection/multi_domain_boussinesq_convection.cc
+++ b/demo_drivers/mpi/multi_domain/boussinesq_convection/multi_domain_boussinesq_convection.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/multi_domain/boussinesq_convection/multi_domain_ref_b_convection.cc
+++ b/demo_drivers/mpi/multi_domain/boussinesq_convection/multi_domain_ref_b_convection.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/multi_domain/boussinesq_convection/refineable_b_convection.cc
+++ b/demo_drivers/mpi/multi_domain/boussinesq_convection/refineable_b_convection.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/multi_domain/fsi_channel_with_leaflet/fsi_channel_with_leaflet.cc
+++ b/demo_drivers/mpi/multi_domain/fsi_channel_with_leaflet/fsi_channel_with_leaflet.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/multi_domain/fsi_collapsible_channel/fsi_collapsible_channel_adapt.cc
+++ b/demo_drivers/mpi/multi_domain/fsi_collapsible_channel/fsi_collapsible_channel_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/multi_domain/fsi_osc_ring/fsi_osc_ring.cc
+++ b/demo_drivers/mpi/multi_domain/fsi_osc_ring/fsi_osc_ring.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/multi_domain/pseudo_solid_collapsible_tube/pseudo_solid_collapsible_tube.cc
+++ b/demo_drivers/mpi/multi_domain/pseudo_solid_collapsible_tube/pseudo_solid_collapsible_tube.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/multi_domain/turek_flag/turek_flag.cc
+++ b/demo_drivers/mpi/multi_domain/turek_flag/turek_flag.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/multi_domain/turek_flag/turek_flag_load_balance.cc
+++ b/demo_drivers/mpi/multi_domain/turek_flag/turek_flag_load_balance.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/solvers/TrilinosSolver_test.cc
+++ b/demo_drivers/mpi/solvers/TrilinosSolver_test.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/solvers/airy_cantilever.cc
+++ b/demo_drivers/mpi/solvers/airy_cantilever.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/solvers/direct_solver_test.cc
+++ b/demo_drivers/mpi/solvers/direct_solver_test.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/solvers/driven_cavity.cc
+++ b/demo_drivers/mpi/solvers/driven_cavity.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/solvers/fsi_channel_with_leaflet.cc
+++ b/demo_drivers/mpi/solvers/fsi_channel_with_leaflet.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/mpi/solvers/two_d_multi_poisson.cc
+++ b/demo_drivers/mpi/solvers/two_d_multi_poisson.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/3d_boussinesq_convection/3d_multimesh_ref_b_convect.cc
+++ b/demo_drivers/multi_physics/3d_boussinesq_convection/3d_multimesh_ref_b_convect.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/3d_boussinesq_convection/3d_ref_b_convect.cc
+++ b/demo_drivers/multi_physics/3d_boussinesq_convection/3d_ref_b_convect.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/3d_boussinesq_convection/my_boussinesq_elements.h
+++ b/demo_drivers/multi_physics/3d_boussinesq_convection/my_boussinesq_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/axisym_heat_sphere/axisym_buoyant_navier_stokes.h
+++ b/demo_drivers/multi_physics/axisym_heat_sphere/axisym_buoyant_navier_stokes.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/axisym_heat_sphere/axisym_heat_sphere.cc
+++ b/demo_drivers/multi_physics/axisym_heat_sphere/axisym_heat_sphere.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/axisym_heat_sphere/half_rectangle_with_hole_mesh.h
+++ b/demo_drivers/multi_physics/axisym_heat_sphere/half_rectangle_with_hole_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/axisym_heat_sphere/multi_domain_axisym_boussinesq_elements.h
+++ b/demo_drivers/multi_physics/axisym_heat_sphere/multi_domain_axisym_boussinesq_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/axisym_heat_sphere/multi_domain_axisym_heat_sphere.cc
+++ b/demo_drivers/multi_physics/axisym_heat_sphere/multi_domain_axisym_heat_sphere.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/b_convection_sphere/axisym_buoyant_navier_stokes.h
+++ b/demo_drivers/multi_physics/b_convection_sphere/axisym_buoyant_navier_stokes.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/b_convection_sphere/b_convection_sphere.cc
+++ b/demo_drivers/multi_physics/b_convection_sphere/b_convection_sphere.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/b_convection_sphere/half_rectangle_with_hole_mesh.h
+++ b/demo_drivers/multi_physics/b_convection_sphere/half_rectangle_with_hole_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/b_convection_sphere/multi_domain_axisym_boussinesq_elements.h
+++ b/demo_drivers/multi_physics/b_convection_sphere/multi_domain_axisym_boussinesq_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/b_convection_sphere/multi_domain_b_convect_sph.cc
+++ b/demo_drivers/multi_physics/b_convection_sphere/multi_domain_b_convect_sph.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/boussinesq_convection/boussinesq_convection.cc
+++ b/demo_drivers/multi_physics/boussinesq_convection/boussinesq_convection.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/boussinesq_convection/multi_domain_boussinesq_convection.cc
+++ b/demo_drivers/multi_physics/boussinesq_convection/multi_domain_boussinesq_convection.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/boussinesq_convection/multi_domain_ref_b_convection.cc
+++ b/demo_drivers/multi_physics/boussinesq_convection/multi_domain_ref_b_convection.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/boussinesq_convection/refineable_b_convection.cc
+++ b/demo_drivers/multi_physics/boussinesq_convection/refineable_b_convection.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/double_diffusive_convection/db_navier_st_elements.h
+++ b/demo_drivers/multi_physics/double_diffusive_convection/db_navier_st_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/double_diffusive_convection/db_nst_external_elements.h
+++ b/demo_drivers/multi_physics/double_diffusive_convection/db_nst_external_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/double_diffusive_convection/dd_convection.cc
+++ b/demo_drivers/multi_physics/double_diffusive_convection/dd_convection.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/double_diffusive_convection/multimesh_dd_convection.cc
+++ b/demo_drivers/multi_physics/double_diffusive_convection/multimesh_dd_convection.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/double_diffusive_convection/multimesh_ref_dd_convection.cc
+++ b/demo_drivers/multi_physics/double_diffusive_convection/multimesh_ref_dd_convection.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/insoluble_surfactant/surfactant.cc
+++ b/demo_drivers/multi_physics/insoluble_surfactant/surfactant.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/marangoni_convection/marangoni_convection.cc
+++ b/demo_drivers/multi_physics/marangoni_convection/marangoni_convection.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/marangoni_convection/marangoni_convection_box.cc
+++ b/demo_drivers/multi_physics/marangoni_convection/marangoni_convection_box.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/rayleigh_instability_surfactant/3d_rayleigh_instability_surfactant.cc
+++ b/demo_drivers/multi_physics/rayleigh_instability_surfactant/3d_rayleigh_instability_surfactant.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/rayleigh_instability_surfactant/axisymmetric_advection_navier_stokes_elements.h
+++ b/demo_drivers/multi_physics/rayleigh_instability_surfactant/axisymmetric_advection_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/rayleigh_instability_surfactant/rayleigh_instability_insoluble_surfactant.cc
+++ b/demo_drivers/multi_physics/rayleigh_instability_surfactant/rayleigh_instability_insoluble_surfactant.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/rayleigh_instability_surfactant/rayleigh_instability_soluble_surfactant.cc
+++ b/demo_drivers/multi_physics/rayleigh_instability_surfactant/rayleigh_instability_soluble_surfactant.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/soluble_surfactant/double_buoyant_navier_stokes_elements.h
+++ b/demo_drivers/multi_physics/soluble_surfactant/double_buoyant_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/soluble_surfactant/soluble_surfactant.cc
+++ b/demo_drivers/multi_physics/soluble_surfactant/soluble_surfactant.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/spherical_shell_convection/spherical_buoyant_navier_stokes.h
+++ b/demo_drivers/multi_physics/spherical_shell_convection/spherical_buoyant_navier_stokes.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/spherical_shell_convection/spherical_shell_convection.cc
+++ b/demo_drivers/multi_physics/spherical_shell_convection/spherical_shell_convection.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/thermal_fibre/non_isothermal_axisym_nst_elements.h
+++ b/demo_drivers/multi_physics/thermal_fibre/non_isothermal_axisym_nst_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/thermal_fibre/thermal_fibre.cc
+++ b/demo_drivers/multi_physics/thermal_fibre/thermal_fibre.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/thermo/thermo.cc
+++ b/demo_drivers/multi_physics/thermo/thermo.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/two_layer_soluble_surfactant/double_buoyant_navier_stokes_elements.h
+++ b/demo_drivers/multi_physics/two_layer_soluble_surfactant/double_buoyant_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/two_layer_soluble_surfactant/refineable_two_layer_soluble_surfactant.cc
+++ b/demo_drivers/multi_physics/two_layer_soluble_surfactant/refineable_two_layer_soluble_surfactant.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/two_layer_soluble_surfactant/refineable_unstructured_two_layer_ss.cc
+++ b/demo_drivers/multi_physics/two_layer_soluble_surfactant/refineable_unstructured_two_layer_ss.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/two_layer_soluble_surfactant/soluble_surfactant_transport_equations.h
+++ b/demo_drivers/multi_physics/two_layer_soluble_surfactant/soluble_surfactant_transport_equations.h
@@ -1,13 +1,9 @@
-///LIC// ====================================================================
+//LIC// ====================================================================
 //LIC// This file forms part of oomph-lib, the object-oriented, 
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multi_physics/two_layer_soluble_surfactant/two_layer_soluble_surfactant.cc
+++ b/demo_drivers/multi_physics/two_layer_soluble_surfactant/two_layer_soluble_surfactant.cc
@@ -1,13 +1,9 @@
-///LIC// ====================================================================
+//LIC// ====================================================================
 //LIC// This file forms part of oomph-lib, the object-oriented, 
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multigrid/helmholtz_multigrid/structured_cubic_point_source.cc
+++ b/demo_drivers/multigrid/helmholtz_multigrid/structured_cubic_point_source.cc
@@ -1,31 +1,28 @@
-//LIC//======================================================================
-///LIC// This file forms part of oomph-lib,the object-oriented,
-//LIC// multi-physics finite-element library,available
+//LIC// ====================================================================
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//           Version 0.90. August 3,2009.
-//LIC//
-//LIC// Copyright (C) 2006-2009 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
-//LIC// version 2.1 of the License,or (at your option) any later version.
-//LIC//
+//LIC// version 2.1 of the License, or (at your option) any later version.
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
-//LIC// License along with this library; if not,write to the Free Software
-//LIC// Foundation,Inc.,51 Franklin Street,Fifth Floor,Boston,MA
+//LIC// License along with this library; if not, write to the Free Software
+//LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
-//LIC//
-//LIC//======================================================================
+//LIC// 
+//LIC//====================================================================
 // Helmoholtz equation with one PML and forcing on the opposite side and
 // periodic BC on all other sides
 #include <fenv.h>

--- a/demo_drivers/multigrid/helmholtz_multigrid/unstructured_two_d_helmholtz.cc
+++ b/demo_drivers/multigrid/helmholtz_multigrid/unstructured_two_d_helmholtz.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1194 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-27 08:44:43 +0100 (Fri, 27 May 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multigrid/scalar_multigrid/two_d_poisson_tanh_flux_bc.cc
+++ b/demo_drivers/multigrid/scalar_multigrid/two_d_poisson_tanh_flux_bc.cc
@@ -1,29 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//           Version 0.90. August 3, 2009.
-//LIC//
-//LIC// Copyright (C) 2006-2009 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 
 // Generic routines

--- a/demo_drivers/multigrid/scalar_multigrid/two_d_poisson_tanh_flux_bc_validate.cc
+++ b/demo_drivers/multigrid/scalar_multigrid/two_d_poisson_tanh_flux_bc_validate.cc
@@ -3,9 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//           Version 0.90. August 3, 2009.
-//LIC// 
-//LIC// Copyright (C) 2006-2009 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multigrid/scalar_multigrid/unit_cube_poisson.cc
+++ b/demo_drivers/multigrid/scalar_multigrid/unit_cube_poisson.cc
@@ -3,9 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//           Version 0.90. August 3, 2009.
-//LIC// 
-//LIC// Copyright (C) 2006-2009 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/multigrid/scalar_multigrid/unit_cube_poisson_validate.cc
+++ b/demo_drivers/multigrid/scalar_multigrid/unit_cube_poisson_validate.cc
@@ -3,9 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//           Version 0.90. August 3, 2009.
-//LIC// 
-//LIC// Copyright (C) 2006-2009 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/adaptive_driven_cavity/adaptive_driven_cavity.cc
+++ b/demo_drivers/navier_stokes/adaptive_driven_cavity/adaptive_driven_cavity.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/adaptive_interface/adaptive_interface.cc
+++ b/demo_drivers/navier_stokes/adaptive_interface/adaptive_interface.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/bretherton/bretherton.cc
+++ b/demo_drivers/navier_stokes/bretherton/bretherton.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/channel_with_leaflet/channel_with_leaflet.cc
+++ b/demo_drivers/navier_stokes/channel_with_leaflet/channel_with_leaflet.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/circular_driven_cavity/circular_driven_cavity.cc
+++ b/demo_drivers/navier_stokes/circular_driven_cavity/circular_driven_cavity.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/circular_driven_cavity/circular_driven_cavity2.cc
+++ b/demo_drivers/navier_stokes/circular_driven_cavity/circular_driven_cavity2.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/collapsible_channel/collapsible_channel.cc
+++ b/demo_drivers/navier_stokes/collapsible_channel/collapsible_channel.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/collapsible_channel/collapsible_channel_algebraic.cc
+++ b/demo_drivers/navier_stokes/collapsible_channel/collapsible_channel_algebraic.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/collapsible_channel/my_alg_channel_mesh.h
+++ b/demo_drivers/navier_stokes/collapsible_channel/my_alg_channel_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/curved_pipe/curved_pipe.cc
+++ b/demo_drivers/navier_stokes/curved_pipe/curved_pipe.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/curved_pipe/helical_pipe.cc
+++ b/demo_drivers/navier_stokes/curved_pipe/helical_pipe.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/driven_cavity/driven_cavity.cc
+++ b/demo_drivers/navier_stokes/driven_cavity/driven_cavity.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/falling_jet/falling_jet.cc
+++ b/demo_drivers/navier_stokes/falling_jet/falling_jet.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/flow_past_cylinder/flow_past_cylinder.cc
+++ b/demo_drivers/navier_stokes/flow_past_cylinder/flow_past_cylinder.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/flow_past_oscillating_cylinder/flow_past_oscillating_cylinder.cc
+++ b/demo_drivers/navier_stokes/flow_past_oscillating_cylinder/flow_past_oscillating_cylinder.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1162 $
-//LIC//
-//LIC// $LastChangedDate: 2016-04-18 13:27:54 +0100 (Mon, 18 Apr 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Generic oomph-lib stuff
 #include "generic.h"

--- a/demo_drivers/navier_stokes/flux_control/flux_control.cc
+++ b/demo_drivers/navier_stokes/flux_control/flux_control.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/free_surface_rotation/free_surface_rotation.cc
+++ b/demo_drivers/navier_stokes/free_surface_rotation/free_surface_rotation.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/hp_adaptive_driven_cavity/circular_driven_cavity_hp_adapt.cc
+++ b/demo_drivers/navier_stokes/hp_adaptive_driven_cavity/circular_driven_cavity_hp_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/hp_adaptive_driven_cavity/hp_adaptive_driven_cavity.cc
+++ b/demo_drivers/navier_stokes/hp_adaptive_driven_cavity/hp_adaptive_driven_cavity.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/inclined_plane/inclined_plane.cc
+++ b/demo_drivers/navier_stokes/inclined_plane/inclined_plane.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/jeffery_orbit/jeffery_orbit.cc
+++ b/demo_drivers/navier_stokes/jeffery_orbit/jeffery_orbit.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/jeffery_orbit/my_taylor_hood_elements.h
+++ b/demo_drivers/navier_stokes/jeffery_orbit/my_taylor_hood_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/lagrange_enforced_flow_preconditioner/two_d_tilted_square.cc
+++ b/demo_drivers/navier_stokes/lagrange_enforced_flow_preconditioner/two_d_tilted_square.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
@@ -26,7 +22,7 @@
 //LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
 //LIC// 
-//LIC//=====================================================================
+//LIC//====================================================================
 //Driver for 2D tilted rectangle
 
 #include <fenv.h>

--- a/demo_drivers/navier_stokes/navier_stokes_with_singularity/adaptive_driven_cavity.cc
+++ b/demo_drivers/navier_stokes/navier_stokes_with_singularity/adaptive_driven_cavity.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/navier_stokes_with_singularity/driven_cavity.cc
+++ b/demo_drivers/navier_stokes/navier_stokes_with_singularity/driven_cavity.cc
@@ -1,13 +1,9 @@
-//LIC// ===================================================================
+//LIC// ====================================================================
 //LIC// This file forms part of oomph-lib, the object-oriented, 
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/navier_stokes_with_singularity/finite_re_perturbation.h
+++ b/demo_drivers/navier_stokes/navier_stokes_with_singularity/finite_re_perturbation.h
@@ -1,3 +1,28 @@
+//LIC// ====================================================================
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
+//LIC// at http://www.oomph-lib.org.
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
+//LIC// This library is free software; you can redistribute it and/or
+//LIC// modify it under the terms of the GNU Lesser General Public
+//LIC// License as published by the Free Software Foundation; either
+//LIC// version 2.1 of the License, or (at your option) any later version.
+//LIC// 
+//LIC// This library is distributed in the hope that it will be useful,
+//LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
+//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//LIC// Lesser General Public License for more details.
+//LIC// 
+//LIC// You should have received a copy of the GNU Lesser General Public
+//LIC// License along with this library; if not, write to the Free Software
+//LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+//LIC// 02110-1301  USA.
+//LIC// 
+//LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
+//LIC// 
+//LIC//====================================================================
 
 //====================================================================
 /// Christian's perturbation solution

--- a/demo_drivers/navier_stokes/navier_stokes_with_singularity/navier_stokes_elements_with_singularity.h
+++ b/demo_drivers/navier_stokes/navier_stokes_with_singularity/navier_stokes_elements_with_singularity.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/osc_ellipse/osc_quarter_ellipse.cc
+++ b/demo_drivers/navier_stokes/osc_ellipse/osc_quarter_ellipse.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/osc_ring/osc_ring_alg.cc
+++ b/demo_drivers/navier_stokes/osc_ring/osc_ring_alg.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/osc_ring/osc_ring_macro.cc
+++ b/demo_drivers/navier_stokes/osc_ring/osc_ring_macro.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/rayleigh_channel/rayleigh_channel.cc
+++ b/demo_drivers/navier_stokes/rayleigh_channel/rayleigh_channel.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/rayleigh_traction_channel/rayleigh_traction_channel.cc
+++ b/demo_drivers/navier_stokes/rayleigh_traction_channel/rayleigh_traction_channel.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/schur_complement_preconditioner/three_d_fp.cc
+++ b/demo_drivers/navier_stokes/schur_complement_preconditioner/three_d_fp.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/schur_complement_preconditioner/two_d_fp.cc
+++ b/demo_drivers/navier_stokes/schur_complement_preconditioner/two_d_fp.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/single_layer_free_surface/elastic_single_layer.cc
+++ b/demo_drivers/navier_stokes/single_layer_free_surface/elastic_single_layer.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/single_layer_free_surface/spine_single_layer.cc
+++ b/demo_drivers/navier_stokes/single_layer_free_surface/spine_single_layer.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/space_time_flow_past_oscillating_cylinder/space_time_oscillating_cylinder.cc
+++ b/demo_drivers/navier_stokes/space_time_flow_past_oscillating_cylinder/space_time_oscillating_cylinder.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Driver for space-time pulsatile Poiseuille flow
 

--- a/demo_drivers/navier_stokes/spine_channel/simple_spine_channel.cc
+++ b/demo_drivers/navier_stokes/spine_channel/simple_spine_channel.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/spine_channel/spine_channel.cc
+++ b/demo_drivers/navier_stokes/spine_channel/spine_channel.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/spine_channel/spine_channel2.cc
+++ b/demo_drivers/navier_stokes/spine_channel/spine_channel2.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/static_cap/static_single_layer.cc
+++ b/demo_drivers/navier_stokes/static_cap/static_single_layer.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/static_cap/static_two_layer.cc
+++ b/demo_drivers/navier_stokes/static_cap/static_two_layer.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/three_d_bretherton/canyon_spine_mesh.h
+++ b/demo_drivers/navier_stokes/three_d_bretherton/canyon_spine_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/three_d_bretherton/comb_can_spine_mesh.h
+++ b/demo_drivers/navier_stokes/three_d_bretherton/comb_can_spine_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/three_d_bretherton/comb_tip_spine_mesh.h
+++ b/demo_drivers/navier_stokes/three_d_bretherton/comb_tip_spine_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/three_d_bretherton/extra_elements.h
+++ b/demo_drivers/navier_stokes/three_d_bretherton/extra_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/three_d_bretherton/merge_meshes.h
+++ b/demo_drivers/navier_stokes/three_d_bretherton/merge_meshes.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/three_d_bretherton/st_mesh.h
+++ b/demo_drivers/navier_stokes/three_d_bretherton/st_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/three_d_bretherton/three_d_breth.cc
+++ b/demo_drivers/navier_stokes/three_d_bretherton/three_d_breth.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/three_d_bretherton/tip_spine_mesh.h
+++ b/demo_drivers/navier_stokes/three_d_bretherton/tip_spine_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/three_d_entry_flow/full_tube.cc
+++ b/demo_drivers/navier_stokes/three_d_entry_flow/full_tube.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/three_d_entry_flow/three_d_entry_flow.cc
+++ b/demo_drivers/navier_stokes/three_d_entry_flow/three_d_entry_flow.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/three_d_free_surface/3d_free_surface.cc
+++ b/demo_drivers/navier_stokes/three_d_free_surface/3d_free_surface.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/three_d_static_cap/3d_static_cap.cc
+++ b/demo_drivers/navier_stokes/three_d_static_cap/3d_static_cap.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/three_d_static_cap/3d_static_cap_elastic.cc
+++ b/demo_drivers/navier_stokes/three_d_static_cap/3d_static_cap_elastic.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/turek_flag_non_fsi/turek_flag_non_fsi.cc
+++ b/demo_drivers/navier_stokes/turek_flag_non_fsi/turek_flag_non_fsi.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/two_layer_interface/elastic_two_layer_interface.cc
+++ b/demo_drivers/navier_stokes/two_layer_interface/elastic_two_layer_interface.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/two_layer_interface/refineable_two_layer_interface.cc
+++ b/demo_drivers/navier_stokes/two_layer_interface/refineable_two_layer_interface.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/two_layer_interface/spine_two_layer_interface.cc
+++ b/demo_drivers/navier_stokes/two_layer_interface/spine_two_layer_interface.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/unstructured_adaptive_3d_ALE/uns_adapt_3d.cc
+++ b/demo_drivers/navier_stokes/unstructured_adaptive_3d_ALE/uns_adapt_3d.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/unstructured_adaptive_3d_ALE/uns_adapt_3d_fs.cc
+++ b/demo_drivers/navier_stokes/unstructured_adaptive_3d_ALE/uns_adapt_3d_fs.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/unstructured_adaptive_ALE/unstructured_adaptive_ALE.cc
+++ b/demo_drivers/navier_stokes/unstructured_adaptive_ALE/unstructured_adaptive_ALE.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/unstructured_adaptive_fs/adaptive_bubble_in_channel.cc
+++ b/demo_drivers/navier_stokes/unstructured_adaptive_fs/adaptive_bubble_in_channel.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/unstructured_adaptive_fs/adaptive_drop_in_channel.cc
+++ b/demo_drivers/navier_stokes/unstructured_adaptive_fs/adaptive_drop_in_channel.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/unstructured_fluid/unstructured_two_d_fluid.cc
+++ b/demo_drivers/navier_stokes/unstructured_fluid/unstructured_two_d_fluid.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/unstructured_three_d_fluid/unstructured_three_d_fluid.cc
+++ b/demo_drivers/navier_stokes/unstructured_three_d_fluid/unstructured_three_d_fluid.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/vmtk_fluid/vmtk_fluid.cc
+++ b/demo_drivers/navier_stokes/vmtk_fluid/vmtk_fluid.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/navier_stokes/vorticity_smoother/vorticity_smoother_validation.cc
+++ b/demo_drivers/navier_stokes/vorticity_smoother/vorticity_smoother_validation.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/ode/basic_ode/basic_ode.cc
+++ b/demo_drivers/ode/basic_ode/basic_ode.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/ode/my_problem.h
+++ b/demo_drivers/ode/my_problem.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/ode/ode_element_for_imr.h
+++ b/demo_drivers/ode/ode_element_for_imr.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/ode/ode_example_functions.h
+++ b/demo_drivers/ode/ode_example_functions.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/ode/ode_problem.h
+++ b/demo_drivers/ode/ode_problem.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/optimisation/C_style_output/c_style_output.cc
+++ b/demo_drivers/optimisation/C_style_output/c_style_output.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/optimisation/disable_ALE/navier_stokes/ray_circ_cavity_adapt.cc
+++ b/demo_drivers/optimisation/disable_ALE/navier_stokes/ray_circ_cavity_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/optimisation/disable_ALE/navier_stokes/rayleigh_channel.cc
+++ b/demo_drivers/optimisation/disable_ALE/navier_stokes/rayleigh_channel.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/optimisation/disable_ALE/unsteady_heat/two_d_unsteady_heat.cc
+++ b/demo_drivers/optimisation/disable_ALE/unsteady_heat/two_d_unsteady_heat.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/optimisation/disable_ALE/unsteady_heat/two_d_unsteady_heat_adapt.cc
+++ b/demo_drivers/optimisation/disable_ALE/unsteady_heat/two_d_unsteady_heat_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/optimisation/fsi_jacobian_approximation/fsi_jacobian_approximation.cc
+++ b/demo_drivers/optimisation/fsi_jacobian_approximation/fsi_jacobian_approximation.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/optimisation/linear_vs_nonlinear/two_d_poisson.cc
+++ b/demo_drivers/optimisation/linear_vs_nonlinear/two_d_poisson.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/optimisation/sparse_assemble/sparse_assemble_test.cc
+++ b/demo_drivers/optimisation/sparse_assemble/sparse_assemble_test.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/optimisation/stored_shape_fcts/two_d_poisson_stored_shape_fcts.cc
+++ b/demo_drivers/optimisation/stored_shape_fcts/two_d_poisson_stored_shape_fcts.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/optimisation/use_coarse_base_meshes/two_d_poisson_adapt.cc
+++ b/demo_drivers/optimisation/use_coarse_base_meshes/two_d_poisson_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/pml_fourier_decomposed_helmholtz/oscillating_sphere/oscillating_sphere.cc
+++ b/demo_drivers/pml_fourier_decomposed_helmholtz/oscillating_sphere/oscillating_sphere.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/pml_helmholtz/scattering/unstructured_two_d_helmholtz.cc
+++ b/demo_drivers/pml_helmholtz/scattering/unstructured_two_d_helmholtz.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/pml_helmholtz/scattering/unstructured_two_d_helmholtz_scattering.cc
+++ b/demo_drivers/pml_helmholtz/scattering/unstructured_two_d_helmholtz_scattering.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/pml_time_harmonic_linear_elasticity/time_harmonic_elasticity_driver.cc
+++ b/demo_drivers/pml_time_harmonic_linear_elasticity/time_harmonic_elasticity_driver.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/pml_time_harmonic_linear_elasticity/time_harmonic_elasticity_driver_source.cc
+++ b/demo_drivers/pml_time_harmonic_linear_elasticity/time_harmonic_elasticity_driver_source.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/eighth_sphere_poisson/eighth_sphere_poisson.cc
+++ b/demo_drivers/poisson/eighth_sphere_poisson/eighth_sphere_poisson.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/eighth_sphere_poisson_hp_adapt/eighth_sphere_poisson_hp_adapt.cc
+++ b/demo_drivers/poisson/eighth_sphere_poisson_hp_adapt/eighth_sphere_poisson_hp_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/elastic_poisson/elastic_poisson.cc
+++ b/demo_drivers/poisson/elastic_poisson/elastic_poisson.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/fish_poisson/fish_poisson.cc
+++ b/demo_drivers/poisson/fish_poisson/fish_poisson.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/fish_poisson/fish_poisson_no_adapt.cc
+++ b/demo_drivers/poisson/fish_poisson/fish_poisson_no_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/fish_poisson2/fish_domain.cc
+++ b/demo_drivers/poisson/fish_poisson2/fish_domain.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/fish_poisson2/fish_poisson_adapt.cc
+++ b/demo_drivers/poisson/fish_poisson2/fish_poisson_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/fish_poisson2/fish_poisson_no_adapt.cc
+++ b/demo_drivers/poisson/fish_poisson2/fish_poisson_no_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/fish_poisson2/fish_poisson_node_update.cc
+++ b/demo_drivers/poisson/fish_poisson2/fish_poisson_node_update.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/fish_poisson2/fish_poisson_simple_adapt.cc
+++ b/demo_drivers/poisson/fish_poisson2/fish_poisson_simple_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/one_d_poisson/one_d_poisson.cc
+++ b/demo_drivers/poisson/one_d_poisson/one_d_poisson.cc
@@ -1,14 +1,9 @@
-//kruemelmonster
 //LIC// ====================================================================
 //LIC// This file forms part of oomph-lib, the object-oriented, 
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
@@ -28,6 +23,7 @@
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
 //LIC// 
 //LIC//====================================================================
+//kruemelmonster
 //Driver for a simple 1D poisson problem
 
 // Generic oomph-lib routines

--- a/demo_drivers/poisson/one_d_poisson_adapt/one_d_poisson_adapt.cc
+++ b/demo_drivers/poisson/one_d_poisson_adapt/one_d_poisson_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/one_d_poisson_generic_only/one_d_poisson_generic_only.cc
+++ b/demo_drivers/poisson/one_d_poisson_generic_only/one_d_poisson_generic_only.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/one_d_poisson_hp_adapt/one_d_poisson_hp_adapt.cc
+++ b/demo_drivers/poisson/one_d_poisson_hp_adapt/one_d_poisson_hp_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/poisson_with_singularity/poisson_elements_with_singularity.h
+++ b/demo_drivers/poisson/poisson_with_singularity/poisson_elements_with_singularity.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/poisson_with_singularity/two_d_poisson.cc
+++ b/demo_drivers/poisson/poisson_with_singularity/two_d_poisson.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/spectral/one_d_spectral.cc
+++ b/demo_drivers/poisson/spectral/one_d_spectral.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/spectral/three_d_spectral_adapt.cc
+++ b/demo_drivers/poisson/spectral/three_d_spectral_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/spectral/two_d_spectral_adapt.cc
+++ b/demo_drivers/poisson/spectral/two_d_spectral_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/two_d_poisson/two_d_poisson.cc
+++ b/demo_drivers/poisson/two_d_poisson/two_d_poisson.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/two_d_poisson/two_d_poisson2.cc
+++ b/demo_drivers/poisson/two_d_poisson/two_d_poisson2.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/two_d_poisson/two_d_poisson2_mesh.cc
+++ b/demo_drivers/poisson/two_d_poisson/two_d_poisson2_mesh.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/two_d_poisson/two_d_poisson_compare_solvers.cc
+++ b/demo_drivers/poisson/two_d_poisson/two_d_poisson_compare_solvers.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/two_d_poisson_adapt/two_d_poisson_adapt.cc
+++ b/demo_drivers/poisson/two_d_poisson_adapt/two_d_poisson_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/two_d_poisson_flux_bc/two_d_poisson_flux_bc.cc
+++ b/demo_drivers/poisson/two_d_poisson_flux_bc/two_d_poisson_flux_bc.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/two_d_poisson_flux_bc2/two_d_poisson_flux_bc2.cc
+++ b/demo_drivers/poisson/two_d_poisson_flux_bc2/two_d_poisson_flux_bc2.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/two_d_poisson_flux_bc_adapt/two_d_poisson_flux_bc_adapt.cc
+++ b/demo_drivers/poisson/two_d_poisson_flux_bc_adapt/two_d_poisson_flux_bc_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/poisson/two_d_poisson_hp_adapt/two_d_poisson_hp_adapt.cc
+++ b/demo_drivers/poisson/two_d_poisson_hp_adapt/two_d_poisson_hp_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/polar_navier_stokes/jeffery_hamel/jeffery_hamel.cc
+++ b/demo_drivers/polar_navier_stokes/jeffery_hamel/jeffery_hamel.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/polar_navier_stokes/jeffery_hamel/jh_includes.h
+++ b/demo_drivers/polar_navier_stokes/jeffery_hamel/jh_includes.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/polar_navier_stokes/jeffery_hamel/polar_streamfunction_traction_elements.h
+++ b/demo_drivers/polar_navier_stokes/jeffery_hamel/polar_streamfunction_traction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/polar_navier_stokes/jeffery_hamel/refineable_r_mesh.h
+++ b/demo_drivers/polar_navier_stokes/jeffery_hamel/refineable_r_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/polar_navier_stokes/jeffery_hamel/refineable_streamfunction_elements.h
+++ b/demo_drivers/polar_navier_stokes/jeffery_hamel/refineable_streamfunction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/polar_navier_stokes/jeffery_hamel/streamfunction_elements.h
+++ b/demo_drivers/polar_navier_stokes/jeffery_hamel/streamfunction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/polar_navier_stokes/jeffery_hamel/streamfunction_include.h
+++ b/demo_drivers/polar_navier_stokes/jeffery_hamel/streamfunction_include.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/reaction_diffusion/one_d_act_inhibit/one_d_act_inhibit.cc
+++ b/demo_drivers/reaction_diffusion/one_d_act_inhibit/one_d_act_inhibit.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/reaction_diffusion/two_d_act_inhibit/two_d_act_inhibit.cc
+++ b/demo_drivers/reaction_diffusion/two_d_act_inhibit/two_d_act_inhibit.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/reaction_diffusion/two_d_act_inhibit_adapt/two_d_act_inhibit_adapt.cc
+++ b/demo_drivers/reaction_diffusion/two_d_act_inhibit_adapt/two_d_act_inhibit_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/reaction_diffusion/unstructured_two_d_act_inhibit/unstructured_two_d_act_inhibit.cc
+++ b/demo_drivers/reaction_diffusion/unstructured_two_d_act_inhibit/unstructured_two_d_act_inhibit.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1207 $
-//LIC//
-//LIC// $LastChangedDate: 2016-06-24 15:10:32 +0100 (Fri, 24 Jun 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/shell/circular_plate/unstructured_clamped_circular_plate.cc
+++ b/demo_drivers/shell/circular_plate/unstructured_clamped_circular_plate.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/shell/clamped_or_pinned_shell/clamped_or_pinned_shell.cc
+++ b/demo_drivers/shell/clamped_or_pinned_shell/clamped_or_pinned_shell.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/shell/clamped_shell/clamped_shell.cc
+++ b/demo_drivers/shell/clamped_shell/clamped_shell.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/shell/clamped_shell/clamped_shell_with_arclength_cont.cc
+++ b/demo_drivers/shell/clamped_shell/clamped_shell_with_arclength_cont.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/shell/clamped_shell/unstructured_clamped_curved_shell.cc
+++ b/demo_drivers/shell/clamped_shell/unstructured_clamped_curved_shell.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/shell/oscillating_shell/oscillating_shell.cc
+++ b/demo_drivers/shell/oscillating_shell/oscillating_shell.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/shell/plate/plate.cc
+++ b/demo_drivers/shell/plate/plate.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/shell/plate/unstructured_clamped_square_plate.cc
+++ b/demo_drivers/shell/plate/unstructured_clamped_square_plate.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/airy_cantilever/airy_cantilever.cc
+++ b/demo_drivers/solid/airy_cantilever/airy_cantilever.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/airy_cantilever/airy_cantilever2.cc
+++ b/demo_drivers/solid/airy_cantilever/airy_cantilever2.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/compressed_square/compressed_square.cc
+++ b/demo_drivers/solid/compressed_square/compressed_square.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/disk_compression/disk_compression.cc
+++ b/demo_drivers/solid/disk_compression/disk_compression.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/disk_oscillation/disk_oscillation.cc
+++ b/demo_drivers/solid/disk_oscillation/disk_oscillation.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/prescribed_displ_lagr_mult/prescribed_displ_lagr_mult.cc
+++ b/demo_drivers/solid/prescribed_displ_lagr_mult/prescribed_displ_lagr_mult.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/prescribed_displ_lagr_mult/prescribed_displ_lagr_mult2.cc
+++ b/demo_drivers/solid/prescribed_displ_lagr_mult/prescribed_displ_lagr_mult2.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/prescribed_displ_lagr_mult/prescribed_displ_lagr_mult_precond.cc
+++ b/demo_drivers/solid/prescribed_displ_lagr_mult/prescribed_displ_lagr_mult_precond.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/pseudo_solid_collapsible_channel/pseudo_solid_collapsible_channel.cc
+++ b/demo_drivers/solid/pseudo_solid_collapsible_channel/pseudo_solid_collapsible_channel.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/shock_disk/shock_disk.cc
+++ b/demo_drivers/solid/shock_disk/shock_disk.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/simple_shear/precompiled_mesh.cc
+++ b/demo_drivers/solid/simple_shear/precompiled_mesh.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/simple_shear/refineable_simple_shear.cc
+++ b/demo_drivers/solid/simple_shear/refineable_simple_shear.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/simple_shear/simple_shear.cc
+++ b/demo_drivers/solid/simple_shear/simple_shear.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/static_fish/static_fish.cc
+++ b/demo_drivers/solid/static_fish/static_fish.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/three_d_cantilever/three_d_cantilever.cc
+++ b/demo_drivers/solid/three_d_cantilever/three_d_cantilever.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/three_d_prescribed_displ_lagr_mult/three_d_prescribed_displ_lagr_mult.cc
+++ b/demo_drivers/solid/three_d_prescribed_displ_lagr_mult/three_d_prescribed_displ_lagr_mult.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/three_d_traction/three_d_traction.cc
+++ b/demo_drivers/solid/three_d_traction/three_d_traction.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/unstructured_adaptive_solid/unstructured_adaptive_solid.cc
+++ b/demo_drivers/solid/unstructured_adaptive_solid/unstructured_adaptive_solid.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/unstructured_solid/unstructured_three_d_solid.cc
+++ b/demo_drivers/solid/unstructured_solid/unstructured_three_d_solid.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/unstructured_solid/unstructured_two_d_solid.cc
+++ b/demo_drivers/solid/unstructured_solid/unstructured_two_d_solid.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/unstructured_three_d_solid/unstructured_three_d_solid.cc
+++ b/demo_drivers/solid/unstructured_three_d_solid/unstructured_three_d_solid.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/solid/vmtk_solid/vmtk_solid.cc
+++ b/demo_drivers/solid/vmtk_solid/vmtk_solid.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/spherical_advection_diffusion/eluting_sphere/eluting_sphere.cc
+++ b/demo_drivers/spherical_advection_diffusion/eluting_sphere/eluting_sphere.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/spherical_advection_diffusion/eluting_sphere/eluting_sphere_adapt.cc
+++ b/demo_drivers/spherical_advection_diffusion/eluting_sphere/eluting_sphere_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/spherical_navier_stokes/spherical_couette/spherical_couette.cc
+++ b/demo_drivers/spherical_navier_stokes/spherical_couette/spherical_couette.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/spherical_navier_stokes/spin_up/refineable_spin_up.cc
+++ b/demo_drivers/spherical_navier_stokes/spin_up/refineable_spin_up.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/spherical_navier_stokes/spin_up/refineable_spin_up_cyl.cc
+++ b/demo_drivers/spherical_navier_stokes/spin_up/refineable_spin_up_cyl.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/spherical_navier_stokes/spin_up/spin_up.cc
+++ b/demo_drivers/spherical_navier_stokes/spin_up/spin_up.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/spherical_navier_stokes/spin_up/spin_up_cyl.cc
+++ b/demo_drivers/spherical_navier_stokes/spin_up/spin_up_cyl.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/spherical_navier_stokes/steady_rot/steady_rot.cc
+++ b/demo_drivers/spherical_navier_stokes/steady_rot/steady_rot.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/steady_axisym_advection_diffusion/steady_axisym_advection_diffusion/steady_axisym_advection_diffusion.cc
+++ b/demo_drivers/steady_axisym_advection_diffusion/steady_axisym_advection_diffusion/steady_axisym_advection_diffusion.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/time_harmonic_fourier_decomposed_linear_elasticity/cylinder/cylinder.cc
+++ b/demo_drivers/time_harmonic_fourier_decomposed_linear_elasticity/cylinder/cylinder.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/time_harmonic_fourier_decomposed_linear_elasticity/cylinder/pressure_loaded_cylinder.cc
+++ b/demo_drivers/time_harmonic_fourier_decomposed_linear_elasticity/cylinder/pressure_loaded_cylinder.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/time_harmonic_fourier_decomposed_linear_elasticity/cylinder/unstructured_cylinder.cc
+++ b/demo_drivers/time_harmonic_fourier_decomposed_linear_elasticity/cylinder/unstructured_cylinder.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/time_harmonic_linear_elasticity/elastic_annulus/time_harmonic_elastic_annulus.cc
+++ b/demo_drivers/time_harmonic_linear_elasticity/elastic_annulus/time_harmonic_elastic_annulus.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/time_harmonic_linear_elasticity/elastic_annulus/unstructured_time_harmonic_elastic_annulus.cc
+++ b/demo_drivers/time_harmonic_linear_elasticity/elastic_annulus/unstructured_time_harmonic_elastic_annulus.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/unsteady_heat/space_time_two_d_unsteady_heat/test_equal_order_galerkin.cc
+++ b/demo_drivers/unsteady_heat/space_time_two_d_unsteady_heat/test_equal_order_galerkin.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Generic routines
 #include "generic.h"

--- a/demo_drivers/unsteady_heat/space_time_two_d_unsteady_heat/test_equal_order_galerkin_petrov.cc
+++ b/demo_drivers/unsteady_heat/space_time_two_d_unsteady_heat/test_equal_order_galerkin_petrov.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Generic routines
 #include "generic.h"

--- a/demo_drivers/unsteady_heat/space_time_two_d_unsteady_heat/test_mixed_order_galerkin_petrov.cc
+++ b/demo_drivers/unsteady_heat/space_time_two_d_unsteady_heat/test_mixed_order_galerkin_petrov.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Generic routines
 #include "generic.h"

--- a/demo_drivers/unsteady_heat/two_d_unsteady_heat/two_d_unsteady_heat.cc
+++ b/demo_drivers/unsteady_heat/two_d_unsteady_heat/two_d_unsteady_heat.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/unsteady_heat/two_d_unsteady_heat/two_d_unsteady_heat_restarted.cc
+++ b/demo_drivers/unsteady_heat/two_d_unsteady_heat/two_d_unsteady_heat_restarted.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/unsteady_heat/two_d_unsteady_heat_2adapt/two_d_unsteady_heat_2adapt.cc
+++ b/demo_drivers/unsteady_heat/two_d_unsteady_heat_2adapt/two_d_unsteady_heat_2adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/unsteady_heat/two_d_unsteady_heat_ALE/two_d_unsteady_heat_ALE.cc
+++ b/demo_drivers/unsteady_heat/two_d_unsteady_heat_ALE/two_d_unsteady_heat_ALE.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/unsteady_heat/two_d_unsteady_heat_adapt/two_d_unsteady_heat_adapt.cc
+++ b/demo_drivers/unsteady_heat/two_d_unsteady_heat_adapt/two_d_unsteady_heat_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/unsteady_heat/two_d_unsteady_heat_t_adapt/two_d_unsteady_heat_t_adapt.cc
+++ b/demo_drivers/unsteady_heat/two_d_unsteady_heat_t_adapt/two_d_unsteady_heat_t_adapt.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/womersley/one_d_womersley/flux_control_elements_bk.h
+++ b/demo_drivers/womersley/one_d_womersley/flux_control_elements_bk.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/womersley/one_d_womersley/one_d_womersley.cc
+++ b/demo_drivers/womersley/one_d_womersley/one_d_womersley.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/womersley/two_d_womersley/two_d_womersley.cc
+++ b/demo_drivers/womersley/two_d_womersley/two_d_womersley.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/young_laplace/barrel.cc
+++ b/demo_drivers/young_laplace/barrel.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/young_laplace/common_young_laplace_stuff.h
+++ b/demo_drivers/young_laplace/common_young_laplace_stuff.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/young_laplace/refineable_t_junction.cc
+++ b/demo_drivers/young_laplace/refineable_t_junction.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/young_laplace/refineable_young_laplace.cc
+++ b/demo_drivers/young_laplace/refineable_young_laplace.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/young_laplace/spherical_cap_in_cylinder.cc
+++ b/demo_drivers/young_laplace/spherical_cap_in_cylinder.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/demo_drivers/young_laplace/young_laplace.cc
+++ b/demo_drivers/young_laplace/young_laplace.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/external_src/oomph_metis_from_parmetis_3.1.1/Makefile.am
+++ b/external_src/oomph_metis_from_parmetis_3.1.1/Makefile.am
@@ -53,6 +53,14 @@ lib_LTLIBRARIES = liboomph_metis_from_parmetis_3.1.1.la
 liboomph_metis_from_parmetis_3_1_1_la_SOURCES = $(headers_and_sources) $(extra_headers)
 liboomph_metis_from_parmetis_3_1_1_la_LDFLAGS = -static
 
+# Deal with implicit function declaration which causes problems on MacOS
+if HAVE_DARWIN
+CFLAGS += -Wno-implicit-function-declaration
+endif
+
+junk:
+	echo $(CFLAGS)
+
 # The library's include headers:
 #-------------------------------
 # Headers that are to be included in the $(includedir) directory:

--- a/self_test/deliberately_broken_code_for_self_test_test/code_with_warning.cc
+++ b/self_test/deliberately_broken_code_for_self_test_test/code_with_warning.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/deliberately_broken_code_for_self_test_test/deliberately_broken_code.cc
+++ b/self_test/deliberately_broken_code_for_self_test_test/deliberately_broken_code.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/generic/block_selector_test/block_selector_test.cc
+++ b/self_test/generic/block_selector_test/block_selector_test.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/generic/vector_matrix_test/vector_matrix_test.cc
+++ b/self_test/generic/vector_matrix_test/vector_matrix_test.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/line_visualiser/adaptive_driven_cavity.cc
+++ b/self_test/line_visualiser/adaptive_driven_cavity.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/locate_zeta/locate_zeta_tester.cc
+++ b/self_test/locate_zeta/locate_zeta_tester.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/locate_zeta/locate_zeta_tester.h
+++ b/self_test/locate_zeta/locate_zeta_tester.h
@@ -1,3 +1,28 @@
+//LIC// ====================================================================
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
+//LIC// at http://www.oomph-lib.org.
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
+//LIC// This library is free software; you can redistribute it and/or
+//LIC// modify it under the terms of the GNU Lesser General Public
+//LIC// License as published by the Free Software Foundation; either
+//LIC// version 2.1 of the License, or (at your option) any later version.
+//LIC// 
+//LIC// This library is distributed in the hope that it will be useful,
+//LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
+//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//LIC// Lesser General Public License for more details.
+//LIC// 
+//LIC// You should have received a copy of the GNU Lesser General Public
+//LIC// License along with this library; if not, write to the Free Software
+//LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+//LIC// 02110-1301  USA.
+//LIC// 
+//LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
+//LIC// 
+//LIC//====================================================================
 
 // Check locate zeta machinery
 void check_locate_zeta(Mesh* mesh_pt)

--- a/self_test/locate_zeta/locate_zeta_tester_3d.cc
+++ b/self_test/locate_zeta/locate_zeta_tester_3d.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/locate_zeta/locate_zeta_tester_tetgen.cc
+++ b/self_test/locate_zeta/locate_zeta_tester_tetgen.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/locate_zeta/locate_zeta_tester_triangle.cc
+++ b/self_test/locate_zeta/locate_zeta_tester_triangle.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1192 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-25 08:08:37 +0100 (Wed, 25 May 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/matrix_matrix_multiply/matrix_multiply_test.cc
+++ b/self_test/matrix_matrix_multiply/matrix_multiply_test.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/mpi/crdoublematrix_copy_constructor/crdoublematrix_copy_constructor.cc
+++ b/self_test/mpi/crdoublematrix_copy_constructor/crdoublematrix_copy_constructor.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/mpi/distribution_concatenation/distribution_concatenation.cc
+++ b/self_test/mpi/distribution_concatenation/distribution_concatenation.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/mpi/generic_mpi/generic_mpi_test.cc
+++ b/self_test/mpi/generic_mpi/generic_mpi_test.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/mpi/line_visualiser/adaptive_driven_cavity.cc
+++ b/self_test/mpi/line_visualiser/adaptive_driven_cavity.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/mpi/matrix_addition/matrix_addition.cc
+++ b/self_test/mpi/matrix_addition/matrix_addition.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/mpi/matrix_concatenation/matrix_concatenation.cc
+++ b/self_test/mpi/matrix_concatenation/matrix_concatenation.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/mpi/matrix_concatenation_without_communication/matrix_concatenation_without_communication.cc
+++ b/self_test/mpi/matrix_concatenation_without_communication/matrix_concatenation_without_communication.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/mpi/three_d_mesh_dist/three_d_mesh_dist.cc
+++ b/self_test/mpi/three_d_mesh_dist/three_d_mesh_dist.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/mpi/two_d_mesh_dist/two_d_mesh_dist.cc
+++ b/self_test/mpi/two_d_mesh_dist/two_d_mesh_dist.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/mpi/vector_concatenation/vector_concatenation.cc
+++ b/self_test/mpi/vector_concatenation/vector_concatenation.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/mpi/vector_concatenation_without_communication/vector_concatenation_without_communication.cc
+++ b/self_test/mpi/vector_concatenation_without_communication/vector_concatenation_without_communication.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/mpi/vector_split/vector_split.cc
+++ b/self_test/mpi/vector_split/vector_split.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/mpi/vector_split_without_communication/vector_split_without_communication.cc
+++ b/self_test/mpi/vector_split_without_communication/vector_split_without_communication.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/navier_stokes/circular_driven_cavity_driver.cc
+++ b/self_test/navier_stokes/circular_driven_cavity_driver.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/poisson/convergence_tests/q_convergence_2d.cc
+++ b/self_test/poisson/convergence_tests/q_convergence_2d.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/poisson/convergence_tests/q_convergence_3d.cc
+++ b/self_test/poisson/convergence_tests/q_convergence_3d.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/poisson/convergence_tests/t_convergence_2d.cc
+++ b/self_test/poisson/convergence_tests/t_convergence_2d.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/poisson/convergence_tests/t_convergence_3d.cc
+++ b/self_test/poisson/convergence_tests/t_convergence_3d.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/poisson/face_tests/q_faces_2d.cc
+++ b/self_test/poisson/face_tests/q_faces_2d.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/poisson/face_tests/q_faces_3d.cc
+++ b/self_test/poisson/face_tests/q_faces_3d.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/poisson/face_tests/t_faces_2d.cc
+++ b/self_test/poisson/face_tests/t_faces_2d.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/poisson/face_tests/t_faces_3d.cc
+++ b/self_test/poisson/face_tests/t_faces_3d.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/poisson/octree_test/octree_test.cc
+++ b/self_test/poisson/octree_test/octree_test.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/poisson/tree_rotation_tests/tree_2d.cc
+++ b/self_test/poisson/tree_rotation_tests/tree_2d.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/self_test/poisson/tree_rotation_tests/tree_3d.cc
+++ b/self_test/poisson/tree_rotation_tests/tree_3d.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/advection_diffusion/advection_diffusion_elements.cc
+++ b/src/advection_diffusion/advection_diffusion_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/advection_diffusion/advection_diffusion_elements.h
+++ b/src/advection_diffusion/advection_diffusion_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/advection_diffusion/advection_diffusion_flux_elements.h
+++ b/src/advection_diffusion/advection_diffusion_flux_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/advection_diffusion/gen_advection_diffusion_elements.cc
+++ b/src/advection_diffusion/gen_advection_diffusion_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/advection_diffusion/gen_advection_diffusion_elements.h
+++ b/src/advection_diffusion/gen_advection_diffusion_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/advection_diffusion/refineable_advection_diffusion_elements.cc
+++ b/src/advection_diffusion/refineable_advection_diffusion_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/advection_diffusion/refineable_advection_diffusion_elements.h
+++ b/src/advection_diffusion/refineable_advection_diffusion_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/advection_diffusion/refineable_gen_advection_diffusion_elements.cc
+++ b/src/advection_diffusion/refineable_gen_advection_diffusion_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/advection_diffusion/refineable_gen_advection_diffusion_elements.h
+++ b/src/advection_diffusion/refineable_gen_advection_diffusion_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/advection_diffusion/supg_advection_diffusion_elements.cc
+++ b/src/advection_diffusion/supg_advection_diffusion_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/advection_diffusion/supg_advection_diffusion_elements.h
+++ b/src/advection_diffusion/supg_advection_diffusion_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/advection_diffusion_reaction/Tadvection_diffusion_reaction_elements.cc
+++ b/src/advection_diffusion_reaction/Tadvection_diffusion_reaction_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/advection_diffusion_reaction/Tadvection_diffusion_reaction_elements.h
+++ b/src/advection_diffusion_reaction/Tadvection_diffusion_reaction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/advection_diffusion_reaction/advection_diffusion_reaction_elements.cc
+++ b/src/advection_diffusion_reaction/advection_diffusion_reaction_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/advection_diffusion_reaction/advection_diffusion_reaction_elements.h
+++ b/src/advection_diffusion_reaction/advection_diffusion_reaction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/advection_diffusion_reaction/refineable_advection_diffusion_reaction_elements.cc
+++ b/src/advection_diffusion_reaction/refineable_advection_diffusion_reaction_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/advection_diffusion_reaction/refineable_advection_diffusion_reaction_elements.h
+++ b/src/advection_diffusion_reaction/refineable_advection_diffusion_reaction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_advection_diffusion/axisym_advection_diffusion_elements.cc
+++ b/src/axisym_advection_diffusion/axisym_advection_diffusion_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_advection_diffusion/axisym_advection_diffusion_elements.h
+++ b/src/axisym_advection_diffusion/axisym_advection_diffusion_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_advection_diffusion/gen_axisym_advection_diffusion_elements.cc
+++ b/src/axisym_advection_diffusion/gen_axisym_advection_diffusion_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_advection_diffusion/gen_axisym_advection_diffusion_elements.h
+++ b/src/axisym_advection_diffusion/gen_axisym_advection_diffusion_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_advection_diffusion/refineable_axisym_advection_diffusion_elements.cc
+++ b/src/axisym_advection_diffusion/refineable_axisym_advection_diffusion_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_advection_diffusion/refineable_axisym_advection_diffusion_elements.h
+++ b/src/axisym_advection_diffusion/refineable_axisym_advection_diffusion_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_advection_diffusion/refineable_gen_axisym_advection_diffusion_elements.cc
+++ b/src/axisym_advection_diffusion/refineable_gen_axisym_advection_diffusion_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_advection_diffusion/refineable_gen_axisym_advection_diffusion_elements.h
+++ b/src/axisym_advection_diffusion/refineable_gen_axisym_advection_diffusion_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_displ_based_foeppl_von_karman/axisym_displ_based_fvk_elements.cc
+++ b/src/axisym_displ_based_foeppl_von_karman/axisym_displ_based_fvk_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_displ_based_foeppl_von_karman/axisym_displ_based_fvk_elements.h
+++ b/src/axisym_displ_based_foeppl_von_karman/axisym_displ_based_fvk_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_foeppl_von_karman/axisym_fvk_elements.cc
+++ b/src/axisym_foeppl_von_karman/axisym_fvk_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_foeppl_von_karman/axisym_fvk_elements.h
+++ b/src/axisym_foeppl_von_karman/axisym_fvk_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_linear_elasticity/Taxisym_linear_elasticity_elements.cc
+++ b/src/axisym_linear_elasticity/Taxisym_linear_elasticity_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_linear_elasticity/Taxisym_linear_elasticity_elements.h
+++ b/src/axisym_linear_elasticity/Taxisym_linear_elasticity_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_linear_elasticity/axisym_linear_elasticity_elements.cc
+++ b/src/axisym_linear_elasticity/axisym_linear_elasticity_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_linear_elasticity/axisym_linear_elasticity_elements.h
+++ b/src/axisym_linear_elasticity/axisym_linear_elasticity_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_linear_elasticity/axisym_linear_elasticity_traction_elements.h
+++ b/src/axisym_linear_elasticity/axisym_linear_elasticity_traction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_navier_stokes/Taxisym_navier_stokes_elements.cc
+++ b/src/axisym_navier_stokes/Taxisym_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_navier_stokes/Taxisym_navier_stokes_elements.h
+++ b/src/axisym_navier_stokes/Taxisym_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_navier_stokes/axisym_fluid_traction_elements.cc
+++ b/src/axisym_navier_stokes/axisym_fluid_traction_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_navier_stokes/axisym_fluid_traction_elements.h
+++ b/src/axisym_navier_stokes/axisym_fluid_traction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_navier_stokes/axisym_navier_stokes_elements.cc
+++ b/src/axisym_navier_stokes/axisym_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_navier_stokes/axisym_navier_stokes_elements.h
+++ b/src/axisym_navier_stokes/axisym_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_navier_stokes/refineable_axisym_navier_stokes_elements.cc
+++ b/src/axisym_navier_stokes/refineable_axisym_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_navier_stokes/refineable_axisym_navier_stokes_elements.h
+++ b/src/axisym_navier_stokes/refineable_axisym_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_poroelasticity/Taxisym_poroelasticity_elements.cc
+++ b/src/axisym_poroelasticity/Taxisym_poroelasticity_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_poroelasticity/Taxisym_poroelasticity_elements.h
+++ b/src/axisym_poroelasticity/Taxisym_poroelasticity_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_poroelasticity/axisym_poroelastic_fsi_face_elements.h
+++ b/src/axisym_poroelasticity/axisym_poroelastic_fsi_face_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_poroelasticity/axisym_poroelasticity_elements.cc
+++ b/src/axisym_poroelasticity/axisym_poroelasticity_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_poroelasticity/axisym_poroelasticity_elements.h
+++ b/src/axisym_poroelasticity/axisym_poroelasticity_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_poroelasticity/axisym_poroelasticity_face_elements.h
+++ b/src/axisym_poroelasticity/axisym_poroelasticity_face_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_spherical_solid/axisym_solid_elements.cc
+++ b/src/axisym_spherical_solid/axisym_solid_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_spherical_solid/axisym_solid_elements.h
+++ b/src/axisym_spherical_solid/axisym_solid_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/axisym_spherical_solid/axisym_solid_traction_elements.h
+++ b/src/axisym_spherical_solid/axisym_solid_traction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/beam/beam_elements.cc
+++ b/src/beam/beam_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/beam/beam_elements.h
+++ b/src/beam/beam_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/biharmonic/biharmonic_elements.cc
+++ b/src/biharmonic/biharmonic_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/biharmonic/biharmonic_elements.h
+++ b/src/biharmonic/biharmonic_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/biharmonic/biharmonic_flux_elements.cc
+++ b/src/biharmonic/biharmonic_flux_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/biharmonic/biharmonic_flux_elements.h
+++ b/src/biharmonic/biharmonic_flux_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/biharmonic/biharmonic_preconditioner.cc
+++ b/src/biharmonic/biharmonic_preconditioner.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/biharmonic/biharmonic_preconditioner.h
+++ b/src/biharmonic/biharmonic_preconditioner.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/biharmonic/biharmonic_problem.cc
+++ b/src/biharmonic/biharmonic_problem.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/biharmonic/biharmonic_problem.h
+++ b/src/biharmonic/biharmonic_problem.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/constitutive/constitutive_laws.cc
+++ b/src/constitutive/constitutive_laws.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/constitutive/constitutive_laws.h
+++ b/src/constitutive/constitutive_laws.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/darcy/Tdarcy_elements.cc
+++ b/src/darcy/Tdarcy_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/darcy/Tdarcy_elements.h
+++ b/src/darcy/Tdarcy_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/darcy/darcy_elements.cc
+++ b/src/darcy/darcy_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/darcy/darcy_elements.h
+++ b/src/darcy/darcy_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/darcy/darcy_face_elements.h
+++ b/src/darcy/darcy_face_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/fluid_interface/constrained_volume_elements.cc
+++ b/src/fluid_interface/constrained_volume_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/fluid_interface/constrained_volume_elements.h
+++ b/src/fluid_interface/constrained_volume_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/fluid_interface/interface_elements.cc
+++ b/src/fluid_interface/interface_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/fluid_interface/interface_elements.h
+++ b/src/fluid_interface/interface_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/fluid_interface/specific_node_update_interface_elements.h
+++ b/src/fluid_interface/specific_node_update_interface_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/fluid_interface/surfactant_transport_elements.cc
+++ b/src/fluid_interface/surfactant_transport_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/fluid_interface/surfactant_transport_elements.h
+++ b/src/fluid_interface/surfactant_transport_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/flux_transport/euler_elements.cc
+++ b/src/flux_transport/euler_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/flux_transport/euler_elements.h
+++ b/src/flux_transport/euler_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/flux_transport/flux_transport_elements.cc
+++ b/src/flux_transport/flux_transport_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/flux_transport/flux_transport_elements.h
+++ b/src/flux_transport/flux_transport_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/flux_transport/scalar_advection_elements.cc
+++ b/src/flux_transport/scalar_advection_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/flux_transport/scalar_advection_elements.h
+++ b/src/flux_transport/scalar_advection_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/foeppl_von_karman/Tdisplacement_based_foeppl_von_karman_elements.cc
+++ b/src/foeppl_von_karman/Tdisplacement_based_foeppl_von_karman_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/foeppl_von_karman/Tdisplacement_based_foeppl_von_karman_elements.h
+++ b/src/foeppl_von_karman/Tdisplacement_based_foeppl_von_karman_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/foeppl_von_karman/Tfoeppl_von_karman_elements.cc
+++ b/src/foeppl_von_karman/Tfoeppl_von_karman_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/foeppl_von_karman/Tfoeppl_von_karman_elements.h
+++ b/src/foeppl_von_karman/Tfoeppl_von_karman_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/foeppl_von_karman/displacement_based_foeppl_von_karman_elements.cc
+++ b/src/foeppl_von_karman/displacement_based_foeppl_von_karman_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/foeppl_von_karman/displacement_based_foeppl_von_karman_elements.h
+++ b/src/foeppl_von_karman/displacement_based_foeppl_von_karman_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/foeppl_von_karman/foeppl_von_karman_elements.cc
+++ b/src/foeppl_von_karman/foeppl_von_karman_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/foeppl_von_karman/foeppl_von_karman_elements.h
+++ b/src/foeppl_von_karman/foeppl_von_karman_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/foeppl_von_karman/foeppl_von_karman_volume_constraint_element.h
+++ b/src/foeppl_von_karman/foeppl_von_karman_volume_constraint_element.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/fourier_decomposed_helmholtz/Tfourier_decomposed_helmholtz_elements.cc
+++ b/src/fourier_decomposed_helmholtz/Tfourier_decomposed_helmholtz_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/fourier_decomposed_helmholtz/Tfourier_decomposed_helmholtz_elements.h
+++ b/src/fourier_decomposed_helmholtz/Tfourier_decomposed_helmholtz_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/fourier_decomposed_helmholtz/fourier_decomposed_helmholtz_bc_elements.h
+++ b/src/fourier_decomposed_helmholtz/fourier_decomposed_helmholtz_bc_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/fourier_decomposed_helmholtz/fourier_decomposed_helmholtz_elements.cc
+++ b/src/fourier_decomposed_helmholtz/fourier_decomposed_helmholtz_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/fourier_decomposed_helmholtz/fourier_decomposed_helmholtz_elements.h
+++ b/src/fourier_decomposed_helmholtz/fourier_decomposed_helmholtz_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/fourier_decomposed_helmholtz/fourier_decomposed_helmholtz_flux_elements.h
+++ b/src/fourier_decomposed_helmholtz/fourier_decomposed_helmholtz_flux_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generalised_newtonian_axisym_navier_stokes/generalised_newtonian_Taxisym_navier_stokes_elements.cc
+++ b/src/generalised_newtonian_axisym_navier_stokes/generalised_newtonian_Taxisym_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generalised_newtonian_axisym_navier_stokes/generalised_newtonian_Taxisym_navier_stokes_elements.h
+++ b/src/generalised_newtonian_axisym_navier_stokes/generalised_newtonian_Taxisym_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generalised_newtonian_axisym_navier_stokes/generalised_newtonian_axisym_navier_stokes_elements.cc
+++ b/src/generalised_newtonian_axisym_navier_stokes/generalised_newtonian_axisym_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generalised_newtonian_axisym_navier_stokes/generalised_newtonian_axisym_navier_stokes_elements.h
+++ b/src/generalised_newtonian_axisym_navier_stokes/generalised_newtonian_axisym_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generalised_newtonian_axisym_navier_stokes/generalised_newtonian_refineable_axisym_navier_stokes_elements.cc
+++ b/src/generalised_newtonian_axisym_navier_stokes/generalised_newtonian_refineable_axisym_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generalised_newtonian_axisym_navier_stokes/generalised_newtonian_refineable_axisym_navier_stokes_elements.h
+++ b/src/generalised_newtonian_axisym_navier_stokes/generalised_newtonian_refineable_axisym_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generalised_newtonian_navier_stokes/generalised_newtonian_Tnavier_stokes_elements.cc
+++ b/src/generalised_newtonian_navier_stokes/generalised_newtonian_Tnavier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generalised_newtonian_navier_stokes/generalised_newtonian_Tnavier_stokes_elements.h
+++ b/src/generalised_newtonian_navier_stokes/generalised_newtonian_Tnavier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generalised_newtonian_navier_stokes/generalised_newtonian_navier_stokes_elements.cc
+++ b/src/generalised_newtonian_navier_stokes/generalised_newtonian_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generalised_newtonian_navier_stokes/generalised_newtonian_navier_stokes_elements.h
+++ b/src/generalised_newtonian_navier_stokes/generalised_newtonian_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generalised_newtonian_navier_stokes/generalised_newtonian_refineable_navier_stokes_elements.cc
+++ b/src/generalised_newtonian_navier_stokes/generalised_newtonian_refineable_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generalised_newtonian_navier_stokes/generalised_newtonian_refineable_navier_stokes_elements.h
+++ b/src/generalised_newtonian_navier_stokes/generalised_newtonian_refineable_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/Qelement_face_coordinate_translation_schemes.cc
+++ b/src/generic/Qelement_face_coordinate_translation_schemes.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/Qelement_face_coordinate_translation_schemes.h
+++ b/src/generic/Qelement_face_coordinate_translation_schemes.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/Qelements.cc
+++ b/src/generic/Qelements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/Qelements.h
+++ b/src/generic/Qelements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/Qspectral_elements.cc
+++ b/src/generic/Qspectral_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/Qspectral_elements.h
+++ b/src/generic/Qspectral_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/Subparametric_Telements.h
+++ b/src/generic/Subparametric_Telements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/SuperLU_preconditioner.h
+++ b/src/generic/SuperLU_preconditioner.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 #ifndef OOMPH_SuperLU_Preconditioner_HEADER
 #define OOMPH_SuperLU_Preconditioner_HEADER

--- a/src/generic/Telements.cc
+++ b/src/generic/Telements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/Telements.h
+++ b/src/generic/Telements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/Vector.h
+++ b/src/generic/Vector.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/algebraic_elements.cc
+++ b/src/generic/algebraic_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/algebraic_elements.h
+++ b/src/generic/algebraic_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/arpack.h
+++ b/src/generic/arpack.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/assembly_handler.cc
+++ b/src/generic/assembly_handler.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/assembly_handler.h
+++ b/src/generic/assembly_handler.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/binary_tree.cc
+++ b/src/generic/binary_tree.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/binary_tree.h
+++ b/src/generic/binary_tree.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/block_preconditioner.cc
+++ b/src/generic/block_preconditioner.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/block_preconditioner.h
+++ b/src/generic/block_preconditioner.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/brick_mesh.cc
+++ b/src/generic/brick_mesh.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/brick_mesh.h
+++ b/src/generic/brick_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/cfortran.h
+++ b/src/generic/cfortran.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/communicator.cc
+++ b/src/generic/communicator.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/communicator.h
+++ b/src/generic/communicator.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/complex_matrices.cc
+++ b/src/generic/complex_matrices.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/complex_matrices.h
+++ b/src/generic/complex_matrices.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/dg_elements.cc
+++ b/src/generic/dg_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/dg_elements.h
+++ b/src/generic/dg_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/displacement_control_element.h
+++ b/src/generic/displacement_control_element.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/domain.cc
+++ b/src/generic/domain.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/domain.h
+++ b/src/generic/domain.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 #ifndef OOMPH_DOMAIN_HEADER
 #define OOMPH_DOMAIN_HEADER

--- a/src/generic/double_multi_vector.cc
+++ b/src/generic/double_multi_vector.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/double_multi_vector.h
+++ b/src/generic/double_multi_vector.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/double_vector.cc
+++ b/src/generic/double_vector.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/double_vector.h
+++ b/src/generic/double_vector.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/double_vector_with_halo.cc
+++ b/src/generic/double_vector_with_halo.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/double_vector_with_halo.h
+++ b/src/generic/double_vector_with_halo.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/eigen_solver.cc
+++ b/src/generic/eigen_solver.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/eigen_solver.h
+++ b/src/generic/eigen_solver.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/elastic_problems.cc
+++ b/src/generic/elastic_problems.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/elastic_problems.h
+++ b/src/generic/elastic_problems.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/element_with_external_element.cc
+++ b/src/generic/element_with_external_element.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/element_with_external_element.h
+++ b/src/generic/element_with_external_element.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/element_with_moving_nodes.cc
+++ b/src/generic/element_with_moving_nodes.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/element_with_moving_nodes.h
+++ b/src/generic/element_with_moving_nodes.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/elements.cc
+++ b/src/generic/elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/elements.h
+++ b/src/generic/elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 //Header file for classes that define element objects
 

--- a/src/generic/error_estimator.cc
+++ b/src/generic/error_estimator.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/error_estimator.h
+++ b/src/generic/error_estimator.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/explicit_timesteppers.cc
+++ b/src/generic/explicit_timesteppers.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/explicit_timesteppers.h
+++ b/src/generic/explicit_timesteppers.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/extruded_domain.cc
+++ b/src/generic/extruded_domain.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//  Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
-//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-//LIC// 02110-1301 USA.
-//LIC//
+//LIC// 02110-1301  USA.
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // oomph-lib headers
 #include "extruded_domain.h"

--- a/src/generic/extruded_domain.h
+++ b/src/generic/extruded_domain.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//  Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
-//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-//LIC// 02110-1301 USA.
-//LIC//
+//LIC// 02110-1301  USA.
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 #ifndef OOMPH_EXTRUDED_DOMAIN_HEADER
 #define OOMPH_EXTRUDED_DOMAIN_HEADER

--- a/src/generic/extruded_macro_element.cc
+++ b/src/generic/extruded_macro_element.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Necessary oomph-lib headers
 #include "extruded_macro_element.h"

--- a/src/generic/extruded_macro_element.h
+++ b/src/generic/extruded_macro_element.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 #ifndef OOMPH_EXTRUDED_MACRO_ELEMENT_HEADER
 #define OOMPH_EXTRUDED_MACRO_ELEMENT_HEADER

--- a/src/generic/face_element_as_geometric_object.h
+++ b/src/generic/face_element_as_geometric_object.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/face_mesh_project.h
+++ b/src/generic/face_mesh_project.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/frontal.h
+++ b/src/generic/frontal.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/frontal_solver.cc
+++ b/src/generic/frontal_solver.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/frontal_solver.h
+++ b/src/generic/frontal_solver.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/fsi.cc
+++ b/src/generic/fsi.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/fsi.h
+++ b/src/generic/fsi.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/general_purpose_block_preconditioners.cc
+++ b/src/generic/general_purpose_block_preconditioners.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 
 #include "oomph_definitions.h"

--- a/src/generic/general_purpose_block_preconditioners.h
+++ b/src/generic/general_purpose_block_preconditioners.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/general_purpose_preconditioners.cc
+++ b/src/generic/general_purpose_preconditioners.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/general_purpose_preconditioners.h
+++ b/src/generic/general_purpose_preconditioners.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/generalised_newtonian_constitutive_models.h
+++ b/src/generic/generalised_newtonian_constitutive_models.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/generalised_timesteppers.h
+++ b/src/generic/generalised_timesteppers.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/geom_obj_with_boundary.h
+++ b/src/generic/geom_obj_with_boundary.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/geom_objects.h
+++ b/src/generic/geom_objects.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 #ifndef OOMPH_GEOM_OBJECTS_HEADER
 #define OOMPH_GEOM_OBJECTS_HEADER

--- a/src/generic/geometric_multigrid.cc
+++ b/src/generic/geometric_multigrid.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1216 $
-//LIC//
-//LIC// $LastChangedDate: 2016-08-06 15:23:30 +0100 (Sat, 06 Aug 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/geometric_multigrid.h
+++ b/src/generic/geometric_multigrid.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1334 $
-//LIC//
-//LIC// $LastChangedDate: 2019-09-12 15:28:57 +0100 (Thu, 12 Sep 2019) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Include guards
 #ifndef OOMPH_GEOMETRIC_MULTIGRID_HEADER

--- a/src/generic/geompack_scaffold_mesh.cc
+++ b/src/generic/geompack_scaffold_mesh.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/geompack_scaffold_mesh.h
+++ b/src/generic/geompack_scaffold_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/hermite_elements.cc
+++ b/src/generic/hermite_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/hermite_elements.h
+++ b/src/generic/hermite_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/hijacked_elements.cc
+++ b/src/generic/hijacked_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/hijacked_elements.h
+++ b/src/generic/hijacked_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/hp_refineable_elements.cc
+++ b/src/generic/hp_refineable_elements.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 //Non-inline member functions for hp-refineable elements
 

--- a/src/generic/hp_refineable_elements.h
+++ b/src/generic/hp_refineable_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/hypre_solver.cc
+++ b/src/generic/hypre_solver.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/hypre_solver.h
+++ b/src/generic/hypre_solver.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/implicit_midpoint_rule.cc
+++ b/src/generic/implicit_midpoint_rule.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/implicit_midpoint_rule.h
+++ b/src/generic/implicit_midpoint_rule.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/integral.cc
+++ b/src/generic/integral.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/integral.h
+++ b/src/generic/integral.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/iterative_linear_solver.cc
+++ b/src/generic/iterative_linear_solver.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 //The actual solve functions for Iterative solvers.
 

--- a/src/generic/iterative_linear_solver.h
+++ b/src/generic/iterative_linear_solver.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 //This header defines a class for linear iterative solvers
 

--- a/src/generic/lapack_qz.h
+++ b/src/generic/lapack_qz.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/line_mesh.cc
+++ b/src/generic/line_mesh.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/line_mesh.h
+++ b/src/generic/line_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/line_visualiser.h
+++ b/src/generic/line_visualiser.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/linear_algebra_distribution.cc
+++ b/src/generic/linear_algebra_distribution.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/linear_algebra_distribution.h
+++ b/src/generic/linear_algebra_distribution.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/linear_solver.cc
+++ b/src/generic/linear_solver.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 //The actual solve functions for dense LU linear solvers.
 

--- a/src/generic/linear_solver.h
+++ b/src/generic/linear_solver.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/macro_element.cc
+++ b/src/generic/macro_element.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/macro_element.h
+++ b/src/generic/macro_element.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/macro_element_node_update_element.cc
+++ b/src/generic/macro_element_node_update_element.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/macro_element_node_update_element.h
+++ b/src/generic/macro_element_node_update_element.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/map_matrix.h
+++ b/src/generic/map_matrix.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/matrices.cc
+++ b/src/generic/matrices.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/matrices.h
+++ b/src/generic/matrices.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/matrix_vector_product.cc
+++ b/src/generic/matrix_vector_product.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/matrix_vector_product.h
+++ b/src/generic/matrix_vector_product.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/mesh.cc
+++ b/src/generic/mesh.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/mesh.h
+++ b/src/generic/mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/mesh_as_geometric_object.cc
+++ b/src/generic/mesh_as_geometric_object.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/mesh_as_geometric_object.h
+++ b/src/generic/mesh_as_geometric_object.h
@@ -1,3 +1,28 @@
+//LIC// ====================================================================
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
+//LIC// at http://www.oomph-lib.org.
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
+//LIC// This library is free software; you can redistribute it and/or
+//LIC// modify it under the terms of the GNU Lesser General Public
+//LIC// License as published by the Free Software Foundation; either
+//LIC// version 2.1 of the License, or (at your option) any later version.
+//LIC// 
+//LIC// This library is distributed in the hope that it will be useful,
+//LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
+//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//LIC// Lesser General Public License for more details.
+//LIC// 
+//LIC// You should have received a copy of the GNU Lesser General Public
+//LIC// License along with this library; if not, write to the Free Software
+//LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+//LIC// 02110-1301  USA.
+//LIC// 
+//LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
+//LIC// 
+//LIC//====================================================================
 // LIC// ====================================================================
 // LIC// This file forms part of oomph-lib, the object-oriented,
 // LIC// multi-physics finite-element library, available

--- a/src/generic/missing_masters.cc
+++ b/src/generic/missing_masters.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/missing_masters.h
+++ b/src/generic/missing_masters.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/missing_masters.template.cc
+++ b/src/generic/missing_masters.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/multi_domain.cc
+++ b/src/generic/multi_domain.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/multi_domain.h
+++ b/src/generic/multi_domain.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/multi_domain.template.cc
+++ b/src/generic/multi_domain.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/mumps.h
+++ b/src/generic/mumps.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/mumps_solver.cc
+++ b/src/generic/mumps_solver.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/mumps_solver.h
+++ b/src/generic/mumps_solver.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/nodes.cc
+++ b/src/generic/nodes.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/nodes.h
+++ b/src/generic/nodes.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/octree.cc
+++ b/src/generic/octree.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/octree.h
+++ b/src/generic/octree.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/oomph_definitions.cc
+++ b/src/generic/oomph_definitions.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/oomph_definitions.h
+++ b/src/generic/oomph_definitions.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/oomph_utilities.cc
+++ b/src/generic/oomph_utilities.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 #ifdef OOMPH_HAS_MPI
 #include "mpi.h"

--- a/src/generic/oomph_utilities.h
+++ b/src/generic/oomph_utilities.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/orthpoly.cc
+++ b/src/generic/orthpoly.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/orthpoly.h
+++ b/src/generic/orthpoly.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/partitioning.cc
+++ b/src/generic/partitioning.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/partitioning.h
+++ b/src/generic/partitioning.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/periodic_orbit_handler.cc
+++ b/src/generic/periodic_orbit_handler.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/periodic_orbit_handler.h
+++ b/src/generic/periodic_orbit_handler.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/pml_mapping_functions.h
+++ b/src/generic/pml_mapping_functions.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/pml_meshes.cc
+++ b/src/generic/pml_meshes.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/pml_meshes.h
+++ b/src/generic/pml_meshes.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/preconditioner.h
+++ b/src/generic/preconditioner.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/preconditioner_array.cc
+++ b/src/generic/preconditioner_array.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/preconditioner_array.h
+++ b/src/generic/preconditioner_array.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/problem.cc
+++ b/src/generic/problem.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/problem.h
+++ b/src/generic/problem.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 //A generic problem class to keep MH happy
 

--- a/src/generic/projection.h
+++ b/src/generic/projection.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/pseudo_buckling_ring.h
+++ b/src/generic/pseudo_buckling_ring.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/pseudosolid_node_update_elements.cc
+++ b/src/generic/pseudosolid_node_update_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/pseudosolid_node_update_elements.h
+++ b/src/generic/pseudosolid_node_update_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/quad_mesh.cc
+++ b/src/generic/quad_mesh.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/quad_mesh.h
+++ b/src/generic/quad_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/quadtree.cc
+++ b/src/generic/quadtree.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/quadtree.h
+++ b/src/generic/quadtree.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/refineable_brick_element.cc
+++ b/src/generic/refineable_brick_element.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/refineable_brick_element.h
+++ b/src/generic/refineable_brick_element.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/refineable_brick_mesh.h
+++ b/src/generic/refineable_brick_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/refineable_brick_spectral_element.h
+++ b/src/generic/refineable_brick_spectral_element.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 #ifndef OOMPH_REFINEABLE_BRICK_SPECTRAL_ELEMENT_HEADER
 #define OOMPH_REFINEABLE_BRICK_SPECTRAL_ELEMENT_HEADER

--- a/src/generic/refineable_elements.cc
+++ b/src/generic/refineable_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/refineable_elements.h
+++ b/src/generic/refineable_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/refineable_line_element.cc
+++ b/src/generic/refineable_line_element.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/refineable_line_element.h
+++ b/src/generic/refineable_line_element.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/refineable_line_mesh.h
+++ b/src/generic/refineable_line_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/refineable_line_spectral_element.h
+++ b/src/generic/refineable_line_spectral_element.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/refineable_mesh.cc
+++ b/src/generic/refineable_mesh.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/refineable_mesh.h
+++ b/src/generic/refineable_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/refineable_mesh.template.cc
+++ b/src/generic/refineable_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/refineable_quad_element.cc
+++ b/src/generic/refineable_quad_element.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/refineable_quad_element.h
+++ b/src/generic/refineable_quad_element.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/refineable_quad_mesh.h
+++ b/src/generic/refineable_quad_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/refineable_quad_spectral_element.h
+++ b/src/generic/refineable_quad_spectral_element.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/sample_point_container.cc
+++ b/src/generic/sample_point_container.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1282 $
-//LIC//
-//LIC// $LastChangedDate: 2017-01-16 08:27:53 +0000 (Mon, 16 Jan 2017) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/sample_point_container.h
+++ b/src/generic/sample_point_container.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/sample_point_parameters.cc
+++ b/src/generic/sample_point_parameters.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1282 $
-//LIC//
-//LIC// $LastChangedDate: 2017-01-16 08:27:53 +0000 (Mon, 16 Jan 2017) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/sample_point_parameters.h
+++ b/src/generic/sample_point_parameters.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/shape.h
+++ b/src/generic/shape.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/simple_cubic_scaffold_tet_mesh.cc
+++ b/src/generic/simple_cubic_scaffold_tet_mesh.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/simple_cubic_scaffold_tet_mesh.h
+++ b/src/generic/simple_cubic_scaffold_tet_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/sparse_vector.h
+++ b/src/generic/sparse_vector.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/spines.cc
+++ b/src/generic/spines.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/spines.h
+++ b/src/generic/spines.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/stacktrace.h
+++ b/src/generic/stacktrace.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/stored_shape_function_elements.cc
+++ b/src/generic/stored_shape_function_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/stored_shape_function_elements.h
+++ b/src/generic/stored_shape_function_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/sum_of_matrices.cc
+++ b/src/generic/sum_of_matrices.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/sum_of_matrices.h
+++ b/src/generic/sum_of_matrices.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/tet_mesh.cc
+++ b/src/generic/tet_mesh.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/tet_mesh.h
+++ b/src/generic/tet_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/tetgen_scaffold_mesh.cc
+++ b/src/generic/tetgen_scaffold_mesh.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/tetgen_scaffold_mesh.h
+++ b/src/generic/tetgen_scaffold_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/timesteppers.cc
+++ b/src/generic/timesteppers.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/timesteppers.h
+++ b/src/generic/timesteppers.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/trapezoid_rule.h
+++ b/src/generic/trapezoid_rule.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/tree.cc
+++ b/src/generic/tree.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/tree.h
+++ b/src/generic/tree.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/tree.template.cc
+++ b/src/generic/tree.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/triangle_mesh.cc
+++ b/src/generic/triangle_mesh.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/triangle_mesh.h
+++ b/src/generic/triangle_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/triangle_scaffold_mesh.cc
+++ b/src/generic/triangle_scaffold_mesh.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/triangle_scaffold_mesh.h
+++ b/src/generic/triangle_scaffold_mesh.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/trilinos_eigen_solver.cc
+++ b/src/generic/trilinos_eigen_solver.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/trilinos_eigen_solver.h
+++ b/src/generic/trilinos_eigen_solver.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/trilinos_helpers.cc
+++ b/src/generic/trilinos_helpers.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/trilinos_helpers.h
+++ b/src/generic/trilinos_helpers.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/trilinos_preconditioners.cc
+++ b/src/generic/trilinos_preconditioners.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/trilinos_preconditioners.h
+++ b/src/generic/trilinos_preconditioners.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/trilinos_solver.cc
+++ b/src/generic/trilinos_solver.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/trilinos_solver.h
+++ b/src/generic/trilinos_solver.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/unstructured_two_d_mesh_geometry_base.cc
+++ b/src/generic/unstructured_two_d_mesh_geometry_base.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1137 $
-//LIC//
-//LIC// $LastChangedDate: 2016-03-11 23:20:17 +0000 (Fri, 11 Mar 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/unstructured_two_d_mesh_geometry_base.h
+++ b/src/generic/unstructured_two_d_mesh_geometry_base.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/generic/vector_matrix.h
+++ b/src/generic/vector_matrix.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/helmholtz/Thelmholtz_elements.cc
+++ b/src/helmholtz/Thelmholtz_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/helmholtz/Thelmholtz_elements.h
+++ b/src/helmholtz/Thelmholtz_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/helmholtz/helmholtz_bc_elements.h
+++ b/src/helmholtz/helmholtz_bc_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/helmholtz/helmholtz_elements.cc
+++ b/src/helmholtz/helmholtz_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/helmholtz/helmholtz_elements.h
+++ b/src/helmholtz/helmholtz_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/helmholtz/helmholtz_flux_elements.h
+++ b/src/helmholtz/helmholtz_flux_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/helmholtz/refineable_helmholtz_elements.cc
+++ b/src/helmholtz/refineable_helmholtz_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/helmholtz/refineable_helmholtz_elements.h
+++ b/src/helmholtz/refineable_helmholtz_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linear_elasticity/Tlinear_elasticity_elements.cc
+++ b/src/linear_elasticity/Tlinear_elasticity_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linear_elasticity/Tlinear_elasticity_elements.h
+++ b/src/linear_elasticity/Tlinear_elasticity_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linear_elasticity/elasticity_tensor.cc
+++ b/src/linear_elasticity/elasticity_tensor.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linear_elasticity/elasticity_tensor.h
+++ b/src/linear_elasticity/elasticity_tensor.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linear_elasticity/linear_elasticity_elements.cc
+++ b/src/linear_elasticity/linear_elasticity_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linear_elasticity/linear_elasticity_elements.h
+++ b/src/linear_elasticity/linear_elasticity_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linear_elasticity/linear_elasticity_traction_elements.h
+++ b/src/linear_elasticity/linear_elasticity_traction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linear_elasticity/refineable_linear_elasticity_elements.cc
+++ b/src/linear_elasticity/refineable_linear_elasticity_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linear_elasticity/refineable_linear_elasticity_elements.h
+++ b/src/linear_elasticity/refineable_linear_elasticity_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linear_wave/linear_wave_elements.cc
+++ b/src/linear_wave/linear_wave_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linear_wave/linear_wave_elements.h
+++ b/src/linear_wave/linear_wave_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linear_wave/linear_wave_flux_elements.h
+++ b/src/linear_wave/linear_wave_flux_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linear_wave/refineable_linear_wave_elements.cc
+++ b/src/linear_wave/refineable_linear_wave_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linear_wave/refineable_linear_wave_elements.h
+++ b/src/linear_wave/refineable_linear_wave_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linearised_axisym_navier_stokes/linearised_axisym_navier_stokes_elements.cc
+++ b/src/linearised_axisym_navier_stokes/linearised_axisym_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linearised_axisym_navier_stokes/linearised_axisym_navier_stokes_elements.h
+++ b/src/linearised_axisym_navier_stokes/linearised_axisym_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linearised_axisym_navier_stokes/multi_domain_linearised_axisym_navier_stokes_elements.h
+++ b/src/linearised_axisym_navier_stokes/multi_domain_linearised_axisym_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linearised_axisym_navier_stokes/refineable_linearised_axisym_navier_stokes_elements.cc
+++ b/src/linearised_axisym_navier_stokes/refineable_linearised_axisym_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linearised_axisym_navier_stokes/refineable_linearised_axisym_navier_stokes_elements.h
+++ b/src/linearised_axisym_navier_stokes/refineable_linearised_axisym_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linearised_navier_stokes/linearised_navier_stokes_eigenvalue_elements.cc
+++ b/src/linearised_navier_stokes/linearised_navier_stokes_eigenvalue_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linearised_navier_stokes/linearised_navier_stokes_eigenvalue_elements.h
+++ b/src/linearised_navier_stokes/linearised_navier_stokes_eigenvalue_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linearised_navier_stokes/linearised_navier_stokes_elements.cc
+++ b/src/linearised_navier_stokes/linearised_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linearised_navier_stokes/linearised_navier_stokes_elements.h
+++ b/src/linearised_navier_stokes/linearised_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linearised_navier_stokes/multi_domain_linearised_navier_stokes_elements.h
+++ b/src/linearised_navier_stokes/multi_domain_linearised_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linearised_navier_stokes/refineable_linearised_navier_stokes_elements.cc
+++ b/src/linearised_navier_stokes/refineable_linearised_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/linearised_navier_stokes/refineable_linearised_navier_stokes_elements.h
+++ b/src/linearised_navier_stokes/refineable_linearised_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/mesh_smoothing/mesh_smooth.cc
+++ b/src/mesh_smoothing/mesh_smooth.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/mesh_smoothing/mesh_smooth.h
+++ b/src/mesh_smoothing/mesh_smooth.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/annular_domain.h
+++ b/src/meshes/annular_domain.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/annular_mesh.template.cc
+++ b/src/meshes/annular_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/annular_mesh.template.h
+++ b/src/meshes/annular_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/backward_step_mesh.template.cc
+++ b/src/meshes/backward_step_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/backward_step_mesh.template.h
+++ b/src/meshes/backward_step_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/bretherton_spine_mesh.template.cc
+++ b/src/meshes/bretherton_spine_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/bretherton_spine_mesh.template.h
+++ b/src/meshes/bretherton_spine_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/brick_from_tet_mesh.template.cc
+++ b/src/meshes/brick_from_tet_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/brick_from_tet_mesh.template.h
+++ b/src/meshes/brick_from_tet_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/channel_spine_mesh.template.cc
+++ b/src/meshes/channel_spine_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/channel_spine_mesh.template.h
+++ b/src/meshes/channel_spine_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/channel_with_leaflet_domain.h
+++ b/src/meshes/channel_with_leaflet_domain.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/channel_with_leaflet_mesh.template.cc
+++ b/src/meshes/channel_with_leaflet_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/channel_with_leaflet_mesh.template.h
+++ b/src/meshes/channel_with_leaflet_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/circular_shell_mesh.template.cc
+++ b/src/meshes/circular_shell_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/circular_shell_mesh.template.h
+++ b/src/meshes/circular_shell_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/collapsible_channel_domain.h
+++ b/src/meshes/collapsible_channel_domain.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/collapsible_channel_mesh.template.cc
+++ b/src/meshes/collapsible_channel_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/collapsible_channel_mesh.template.h
+++ b/src/meshes/collapsible_channel_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/cylinder_with_flag_domain.cc
+++ b/src/meshes/cylinder_with_flag_domain.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/cylinder_with_flag_domain.h
+++ b/src/meshes/cylinder_with_flag_domain.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/cylinder_with_flag_mesh.template.cc
+++ b/src/meshes/cylinder_with_flag_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/cylinder_with_flag_mesh.template.h
+++ b/src/meshes/cylinder_with_flag_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/eighth_sphere_domain.h
+++ b/src/meshes/eighth_sphere_domain.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/eighth_sphere_mesh.template.cc
+++ b/src/meshes/eighth_sphere_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/eighth_sphere_mesh.template.h
+++ b/src/meshes/eighth_sphere_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/extruded_cube_mesh_from_quad_mesh_with_macro_elements.template.cc
+++ b/src/meshes/extruded_cube_mesh_from_quad_mesh_with_macro_elements.template.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Oomph-lib headers
 #include "extruded_cube_mesh_from_quad_mesh_with_macro_elements.template.h"

--- a/src/meshes/extruded_cube_mesh_from_quad_mesh_with_macro_elements.template.h
+++ b/src/meshes/extruded_cube_mesh_from_quad_mesh_with_macro_elements.template.h
@@ -1,29 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//           Version 0.90. August 3, 2009.
-//LIC//
-//LIC// Copyright (C) 2006-2009 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for ExtrudedCubeMeshFromQuadMesh class
 #ifndef OOMPH_EXTRUDED_CUBE_MESH_FROM_QUAD_MESH_WITH_MACRO_ELEMENTS_HEADER

--- a/src/meshes/fish_domain.h
+++ b/src/meshes/fish_domain.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/fish_mesh.template.cc
+++ b/src/meshes/fish_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/fish_mesh.template.h
+++ b/src/meshes/fish_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/fsi_driven_cavity_mesh.template.cc
+++ b/src/meshes/fsi_driven_cavity_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/fsi_driven_cavity_mesh.template.h
+++ b/src/meshes/fsi_driven_cavity_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/full_circle_domain.h
+++ b/src/meshes/full_circle_domain.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/full_circle_mesh.template.cc
+++ b/src/meshes/full_circle_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/full_circle_mesh.template.h
+++ b/src/meshes/full_circle_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/geompack_mesh.template.cc
+++ b/src/meshes/geompack_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/geompack_mesh.template.h
+++ b/src/meshes/geompack_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/gmsh_tet_mesh.template.cc
+++ b/src/meshes/gmsh_tet_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1174 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-11 10:03:56 +0100 (Wed, 11 May 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/gmsh_tet_mesh.template.h
+++ b/src/meshes/gmsh_tet_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1174 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-11 10:03:56 +0100 (Wed, 11 May 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/hermite_element_quad_mesh.template.cc
+++ b/src/meshes/hermite_element_quad_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/hermite_element_quad_mesh.template.h
+++ b/src/meshes/hermite_element_quad_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/horizontal_single_layer_spine_mesh.template.cc
+++ b/src/meshes/horizontal_single_layer_spine_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/horizontal_single_layer_spine_mesh.template.h
+++ b/src/meshes/horizontal_single_layer_spine_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/one_d_lagrangian_mesh.template.cc
+++ b/src/meshes/one_d_lagrangian_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/one_d_lagrangian_mesh.template.h
+++ b/src/meshes/one_d_lagrangian_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/one_d_mesh.template.cc
+++ b/src/meshes/one_d_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/one_d_mesh.template.h
+++ b/src/meshes/one_d_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/quad_from_triangle_mesh.template.cc
+++ b/src/meshes/quad_from_triangle_mesh.template.cc
@@ -1,11 +1,9 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
+//LIC// This file forms part of oomph-lib, the object-oriented, 
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//           Version 0.90. August 3, 2009.
-//LIC// 
-//LIC// Copyright (C) 2006-2009 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/quad_from_triangle_mesh.template.h
+++ b/src/meshes/quad_from_triangle_mesh.template.h
@@ -3,9 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//           Version 0.90. August 3, 2009.
-//LIC// 
-//LIC// Copyright (C) 2006-2009 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/quarter_circle_sector_domain.h
+++ b/src/meshes/quarter_circle_sector_domain.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/quarter_circle_sector_mesh.template.cc
+++ b/src/meshes/quarter_circle_sector_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/quarter_circle_sector_mesh.template.h
+++ b/src/meshes/quarter_circle_sector_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/quarter_pipe_domain.h
+++ b/src/meshes/quarter_pipe_domain.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/quarter_pipe_mesh.template.cc
+++ b/src/meshes/quarter_pipe_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/quarter_pipe_mesh.template.h
+++ b/src/meshes/quarter_pipe_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/quarter_tube_domain.h
+++ b/src/meshes/quarter_tube_domain.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/quarter_tube_mesh.template.cc
+++ b/src/meshes/quarter_tube_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/quarter_tube_mesh.template.h
+++ b/src/meshes/quarter_tube_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/rectangle_with_hole_domain.h
+++ b/src/meshes/rectangle_with_hole_domain.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/rectangle_with_hole_mesh.template.cc
+++ b/src/meshes/rectangle_with_hole_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/rectangle_with_hole_mesh.template.h
+++ b/src/meshes/rectangle_with_hole_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/rectangle_with_moving_cylinder_mesh.template.cc
+++ b/src/meshes/rectangle_with_moving_cylinder_mesh.template.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1162 $
-//LIC//
-//LIC// $LastChangedDate: 2016-04-18 13:27:54 +0100 (Mon, 18 Apr 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Add in the header file
 #include "rectangle_with_moving_cylinder_mesh.template.h"

--- a/src/meshes/rectangle_with_moving_cylinder_mesh.template.h
+++ b/src/meshes/rectangle_with_moving_cylinder_mesh.template.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1162 $
-//LIC//
-//LIC// $LastChangedDate: 2016-04-18 13:27:54 +0100 (Mon, 18 Apr 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for SpaceTimeNavierStokesMixedOrder elements
 #ifndef OOMPH_RECTANGLE_WITH_MOVING_CYLINDER_MESH_HEADER

--- a/src/meshes/rectangular_quadmesh.template.cc
+++ b/src/meshes/rectangular_quadmesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/rectangular_quadmesh.template.h
+++ b/src/meshes/rectangular_quadmesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/refineable_tetgen_mesh.template.cc
+++ b/src/meshes/refineable_tetgen_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1174 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-11 10:03:56 +0100 (Wed, 11 May 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/refineable_tetgen_mesh.template.h
+++ b/src/meshes/refineable_tetgen_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1174 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-11 10:03:56 +0100 (Wed, 11 May 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/simple_cubic_mesh.template.cc
+++ b/src/meshes/simple_cubic_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/simple_cubic_mesh.template.h
+++ b/src/meshes/simple_cubic_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/simple_cubic_tet_mesh.template.cc
+++ b/src/meshes/simple_cubic_tet_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/simple_cubic_tet_mesh.template.h
+++ b/src/meshes/simple_cubic_tet_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/simple_rectangular_quadmesh.template.cc
+++ b/src/meshes/simple_rectangular_quadmesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/simple_rectangular_quadmesh.template.h
+++ b/src/meshes/simple_rectangular_quadmesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/simple_rectangular_tri_mesh.template.cc
+++ b/src/meshes/simple_rectangular_tri_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/simple_rectangular_tri_mesh.template.h
+++ b/src/meshes/simple_rectangular_tri_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/single_layer_cubic_spine_mesh.template.cc
+++ b/src/meshes/single_layer_cubic_spine_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/single_layer_cubic_spine_mesh.template.h
+++ b/src/meshes/single_layer_cubic_spine_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/single_layer_spine_mesh.template.cc
+++ b/src/meshes/single_layer_spine_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/single_layer_spine_mesh.template.h
+++ b/src/meshes/single_layer_spine_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/tetgen_mesh.template.cc
+++ b/src/meshes/tetgen_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/tetgen_mesh.template.h
+++ b/src/meshes/tetgen_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/thin_layer_brick_on_tet_mesh.template.cc
+++ b/src/meshes/thin_layer_brick_on_tet_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/thin_layer_brick_on_tet_mesh.template.h
+++ b/src/meshes/thin_layer_brick_on_tet_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/topologically_rectangular_domain.cc
+++ b/src/meshes/topologically_rectangular_domain.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/topologically_rectangular_domain.h
+++ b/src/meshes/topologically_rectangular_domain.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/triangle_mesh.template.cc
+++ b/src/meshes/triangle_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/triangle_mesh.template.h
+++ b/src/meshes/triangle_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/tube_domain.h
+++ b/src/meshes/tube_domain.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/tube_mesh.template.cc
+++ b/src/meshes/tube_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/tube_mesh.template.h
+++ b/src/meshes/tube_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/two_layer_spine_mesh.template.cc
+++ b/src/meshes/two_layer_spine_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/two_layer_spine_mesh.template.h
+++ b/src/meshes/two_layer_spine_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/xda_tet_mesh.template.cc
+++ b/src/meshes/xda_tet_mesh.template.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/meshes/xda_tet_mesh.template.h
+++ b/src/meshes/xda_tet_mesh.template.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/multi_physics/boussinesq_elements.h
+++ b/src/multi_physics/boussinesq_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/multi_physics/fourier_decomposed_helmholtz_time_harmonic_linear_elasticity_interaction.h
+++ b/src/multi_physics/fourier_decomposed_helmholtz_time_harmonic_linear_elasticity_interaction.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/multi_physics/fsi_preconditioners.h
+++ b/src/multi_physics/fsi_preconditioners.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/multi_physics/helmholtz_time_harmonic_linear_elasticity_interaction.h
+++ b/src/multi_physics/helmholtz_time_harmonic_linear_elasticity_interaction.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/multi_physics/multi_domain_boussinesq_elements.h
+++ b/src/multi_physics/multi_domain_boussinesq_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/multi_physics/pml_helmholtz_time_harmonic_linear_elasticity_interaction.h
+++ b/src/multi_physics/pml_helmholtz_time_harmonic_linear_elasticity_interaction.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/multi_physics/pseudo_elastic_fsi_preconditioner.cc
+++ b/src/multi_physics/pseudo_elastic_fsi_preconditioner.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/multi_physics/pseudo_elastic_fsi_preconditioner.h
+++ b/src/multi_physics/pseudo_elastic_fsi_preconditioner.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/multi_physics/pseudo_elastic_preconditioner.cc
+++ b/src/multi_physics/pseudo_elastic_preconditioner.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/multi_physics/pseudo_elastic_preconditioner.h
+++ b/src/multi_physics/pseudo_elastic_preconditioner.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/multi_physics/segregated_fsi_solver.cc
+++ b/src/multi_physics/segregated_fsi_solver.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/multi_physics/segregated_fsi_solver.h
+++ b/src/multi_physics/segregated_fsi_solver.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/navier_stokes/Tnavier_stokes_elements.cc
+++ b/src/navier_stokes/Tnavier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/navier_stokes/Tnavier_stokes_elements.h
+++ b/src/navier_stokes/Tnavier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/navier_stokes/fluid_traction_elements.h
+++ b/src/navier_stokes/fluid_traction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/navier_stokes/impose_impenetrability_element.h
+++ b/src/navier_stokes/impose_impenetrability_element.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/navier_stokes/impose_parallel_outflow_element.h
+++ b/src/navier_stokes/impose_parallel_outflow_element.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/navier_stokes/lagrange_enforced_flow_preconditioner.cc
+++ b/src/navier_stokes/lagrange_enforced_flow_preconditioner.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
@@ -26,7 +22,7 @@
 //LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
 //LIC// 
-//LIC//=====================================================================
+//LIC//====================================================================
 #include "lagrange_enforced_flow_preconditioner.h"
 
 namespace oomph

--- a/src/navier_stokes/lagrange_enforced_flow_preconditioner.h
+++ b/src/navier_stokes/lagrange_enforced_flow_preconditioner.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
@@ -26,7 +22,7 @@
 //LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
 //LIC// 
-//LIC//=====================================================================
+//LIC//====================================================================
 #ifndef OOMPH_LAGRANGE_ENFORCED_FLOW_PRECONDITIONERS_HEADER
 #define OOMPH_LAGRANGE_ENFORCED_FLOW_PRECONDITIONERS_HEADER
 

--- a/src/navier_stokes/navier_stokes_elements.cc
+++ b/src/navier_stokes/navier_stokes_elements.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 //Non-inline functions for NS elements
 

--- a/src/navier_stokes/navier_stokes_elements.h
+++ b/src/navier_stokes/navier_stokes_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 //Header file for Navier Stokes elements
 

--- a/src/navier_stokes/navier_stokes_flux_control_elements.h
+++ b/src/navier_stokes/navier_stokes_flux_control_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/navier_stokes/navier_stokes_preconditioners.cc
+++ b/src/navier_stokes/navier_stokes_preconditioners.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/navier_stokes/navier_stokes_preconditioners.h
+++ b/src/navier_stokes/navier_stokes_preconditioners.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/navier_stokes/navier_stokes_surface_drag_torque_elements.h
+++ b/src/navier_stokes/navier_stokes_surface_drag_torque_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/navier_stokes/navier_stokes_surface_power_elements.h
+++ b/src/navier_stokes/navier_stokes_surface_power_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/navier_stokes/refineable_navier_stokes_elements.cc
+++ b/src/navier_stokes/refineable_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/navier_stokes/refineable_navier_stokes_elements.h
+++ b/src/navier_stokes/refineable_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/navier_stokes/vorticity_smoother.h
+++ b/src/navier_stokes/vorticity_smoother.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 //Header file for Navier Stokes elements
 

--- a/src/ode/ode_elements.cc
+++ b/src/ode/ode_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/ode/ode_elements.h
+++ b/src/ode/ode_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/pml_fourier_decomposed_helmholtz/Tpml_fourier_decomposed_helmholtz_elements.cc
+++ b/src/pml_fourier_decomposed_helmholtz/Tpml_fourier_decomposed_helmholtz_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/pml_fourier_decomposed_helmholtz/Tpml_fourier_decomposed_helmholtz_elements.h
+++ b/src/pml_fourier_decomposed_helmholtz/Tpml_fourier_decomposed_helmholtz_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/pml_fourier_decomposed_helmholtz/pml_fourier_decomposed_helmholtz_elements.cc
+++ b/src/pml_fourier_decomposed_helmholtz/pml_fourier_decomposed_helmholtz_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/pml_fourier_decomposed_helmholtz/pml_fourier_decomposed_helmholtz_elements.h
+++ b/src/pml_fourier_decomposed_helmholtz/pml_fourier_decomposed_helmholtz_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/pml_fourier_decomposed_helmholtz/pml_fourier_decomposed_helmholtz_flux_elements.h
+++ b/src/pml_fourier_decomposed_helmholtz/pml_fourier_decomposed_helmholtz_flux_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/pml_helmholtz/Tpml_helmholtz_elements.h
+++ b/src/pml_helmholtz/Tpml_helmholtz_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/pml_helmholtz/complex_smoother.h
+++ b/src/pml_helmholtz/complex_smoother.h
@@ -1,3 +1,28 @@
+//LIC// ====================================================================
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
+//LIC// at http://www.oomph-lib.org.
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
+//LIC// This library is free software; you can redistribute it and/or
+//LIC// modify it under the terms of the GNU Lesser General Public
+//LIC// License as published by the Free Software Foundation; either
+//LIC// version 2.1 of the License, or (at your option) any later version.
+//LIC// 
+//LIC// This library is distributed in the hope that it will be useful,
+//LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
+//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//LIC// Lesser General Public License for more details.
+//LIC// 
+//LIC// You should have received a copy of the GNU Lesser General Public
+//LIC// License along with this library; if not, write to the Free Software
+//LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+//LIC// 02110-1301  USA.
+//LIC// 
+//LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
+//LIC// 
+//LIC//====================================================================
 //Include guards
 #ifndef OOMPH_COMPLEX_SMOOTHER_HEADER
 #define OOMPH_COMPLEX_SMOOTHER_HEADER

--- a/src/pml_helmholtz/helmholtz_geometric_multigrid.h
+++ b/src/pml_helmholtz/helmholtz_geometric_multigrid.h
@@ -1,3 +1,28 @@
+//LIC// ====================================================================
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
+//LIC// at http://www.oomph-lib.org.
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
+//LIC// This library is free software; you can redistribute it and/or
+//LIC// modify it under the terms of the GNU Lesser General Public
+//LIC// License as published by the Free Software Foundation; either
+//LIC// version 2.1 of the License, or (at your option) any later version.
+//LIC// 
+//LIC// This library is distributed in the hope that it will be useful,
+//LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
+//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//LIC// Lesser General Public License for more details.
+//LIC// 
+//LIC// You should have received a copy of the GNU Lesser General Public
+//LIC// License along with this library; if not, write to the Free Software
+//LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+//LIC// 02110-1301  USA.
+//LIC// 
+//LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
+//LIC// 
+//LIC//====================================================================
 // Include guards
 #ifndef OOMPH_HELMHOLTZ_GEOMETRIC_MULTIGRID_HEADER
 #define OOMPH_HELMHOLTZ_GEOMETRIC_MULTIGRID_HEADER

--- a/src/pml_helmholtz/pml_helmholtz_elements.cc
+++ b/src/pml_helmholtz/pml_helmholtz_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/pml_helmholtz/pml_helmholtz_elements.h
+++ b/src/pml_helmholtz/pml_helmholtz_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 //Header file for Helmholtz elements
 #ifndef OOMPH_PML_HELMHOLTZ_ELEMENTS_HEADER

--- a/src/pml_helmholtz/pml_helmholtz_flux_elements.h
+++ b/src/pml_helmholtz/pml_helmholtz_flux_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/pml_helmholtz/refineable_pml_helmholtz_elements.cc
+++ b/src/pml_helmholtz/refineable_pml_helmholtz_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/pml_helmholtz/refineable_pml_helmholtz_elements.h
+++ b/src/pml_helmholtz/refineable_pml_helmholtz_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/pml_time_harmonic_linear_elasticity/Tpml_time_harmonic_linear_elasticity_elements.cc
+++ b/src/pml_time_harmonic_linear_elasticity/Tpml_time_harmonic_linear_elasticity_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/pml_time_harmonic_linear_elasticity/Tpml_time_harmonic_linear_elasticity_elements.h
+++ b/src/pml_time_harmonic_linear_elasticity/Tpml_time_harmonic_linear_elasticity_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/pml_time_harmonic_linear_elasticity/pml_time_harmonic_elasticity_tensor.cc
+++ b/src/pml_time_harmonic_linear_elasticity/pml_time_harmonic_elasticity_tensor.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/pml_time_harmonic_linear_elasticity/pml_time_harmonic_elasticity_tensor.h
+++ b/src/pml_time_harmonic_linear_elasticity/pml_time_harmonic_elasticity_tensor.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/pml_time_harmonic_linear_elasticity/pml_time_harmonic_linear_elasticity_elements.cc
+++ b/src/pml_time_harmonic_linear_elasticity/pml_time_harmonic_linear_elasticity_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/pml_time_harmonic_linear_elasticity/pml_time_harmonic_linear_elasticity_elements.h
+++ b/src/pml_time_harmonic_linear_elasticity/pml_time_harmonic_linear_elasticity_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/pml_time_harmonic_linear_elasticity/pml_time_harmonic_linear_elasticity_traction_elements.h
+++ b/src/pml_time_harmonic_linear_elasticity/pml_time_harmonic_linear_elasticity_traction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/poisson/Tpoisson_elements.cc
+++ b/src/poisson/Tpoisson_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/poisson/Tpoisson_elements.h
+++ b/src/poisson/Tpoisson_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/poisson/poisson_elements.cc
+++ b/src/poisson/poisson_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/poisson/poisson_elements.h
+++ b/src/poisson/poisson_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/poisson/poisson_flux_elements.h
+++ b/src/poisson/poisson_flux_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/poisson/refineable_poisson_elements.cc
+++ b/src/poisson/refineable_poisson_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/poisson/refineable_poisson_elements.h
+++ b/src/poisson/refineable_poisson_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/poisson/refineable_spectral_poisson_elements.h
+++ b/src/poisson/refineable_spectral_poisson_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/poisson/spectral_poisson_elements.cc
+++ b/src/poisson/spectral_poisson_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/poisson/spectral_poisson_elements.h
+++ b/src/poisson/spectral_poisson_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/polar_navier_stokes/polar_fluid_traction_elements.h
+++ b/src/polar_navier_stokes/polar_fluid_traction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/polar_navier_stokes/polar_navier_stokes_elements.cc
+++ b/src/polar_navier_stokes/polar_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/polar_navier_stokes/polar_navier_stokes_elements.h
+++ b/src/polar_navier_stokes/polar_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/polar_navier_stokes/polar_stress_integral_elements.h
+++ b/src/polar_navier_stokes/polar_stress_integral_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/polar_navier_stokes/refineable_polar_navier_stokes_elements.cc
+++ b/src/polar_navier_stokes/refineable_polar_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/polar_navier_stokes/refineable_polar_navier_stokes_elements.h
+++ b/src/polar_navier_stokes/refineable_polar_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/poroelasticity/Tporoelasticity_elements.cc
+++ b/src/poroelasticity/Tporoelasticity_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/poroelasticity/Tporoelasticity_elements.h
+++ b/src/poroelasticity/Tporoelasticity_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/poroelasticity/elasticity_tensor.cc
+++ b/src/poroelasticity/elasticity_tensor.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/poroelasticity/elasticity_tensor.h
+++ b/src/poroelasticity/elasticity_tensor.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/poroelasticity/poroelasticity_elements.cc
+++ b/src/poroelasticity/poroelasticity_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/poroelasticity/poroelasticity_elements.h
+++ b/src/poroelasticity/poroelasticity_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/poroelasticity/poroelasticity_face_elements.h
+++ b/src/poroelasticity/poroelasticity_face_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/rigid_body/immersed_rigid_body_elements.cc
+++ b/src/rigid_body/immersed_rigid_body_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/rigid_body/immersed_rigid_body_elements.h
+++ b/src/rigid_body/immersed_rigid_body_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/shell/shell_elements.cc
+++ b/src/shell/shell_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/shell/shell_elements.h
+++ b/src/shell/shell_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/solid/refineable_solid_elements.cc
+++ b/src/solid/refineable_solid_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/solid/refineable_solid_elements.h
+++ b/src/solid/refineable_solid_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/solid/solid_elements.cc
+++ b/src/solid/solid_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/solid/solid_elements.h
+++ b/src/solid/solid_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/solid/solid_preconditioners.cc
+++ b/src/solid/solid_preconditioners.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/solid/solid_preconditioners.h
+++ b/src/solid/solid_preconditioners.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/solid/solid_traction_elements.h
+++ b/src/solid/solid_traction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/space_time/space_time_block_preconditioner/general_purpose_space_time_block_preconditionable_elements.h
+++ b/src/space_time/space_time_block_preconditioner/general_purpose_space_time_block_preconditionable_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for SpaceTimeUnsteadyHeat elements
 #ifndef OOMPH_GENERAL_PURPOSE_SPACETIME_BLOCK_PRECONDITIONABLE_ELEMENTS_HEADER

--- a/src/space_time/space_time_block_preconditioner/general_purpose_space_time_block_preconditioner.cc
+++ b/src/space_time/space_time_block_preconditioner/general_purpose_space_time_block_preconditioner.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Oomph-lib headers
 #include "generic/SuperLU_preconditioner.h"

--- a/src/space_time/space_time_block_preconditioner/general_purpose_space_time_block_preconditioner.h
+++ b/src/space_time/space_time_block_preconditioner/general_purpose_space_time_block_preconditioner.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for SpaceTime elements
 #ifndef OOMPH_GENERAL_PURPOSE_SPACE_TIME_BLOCK_PRECONDITIONER_HEADER

--- a/src/space_time/space_time_block_preconditioner/general_purpose_space_time_subsidiary_block_preconditioner.cc
+++ b/src/space_time/space_time_block_preconditioner/general_purpose_space_time_subsidiary_block_preconditioner.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file
 #include "general_purpose_space_time_subsidiary_block_preconditioner.h"

--- a/src/space_time/space_time_block_preconditioner/general_purpose_space_time_subsidiary_block_preconditioner.h
+++ b/src/space_time/space_time_block_preconditioner/general_purpose_space_time_subsidiary_block_preconditioner.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for SpaceTimeNavierStokes elements
 #ifndef OOMPH_GENERAL_PURPOSE_SPACE_TIME_SUBSIDIARY_BLOCK_PRECONDITIONER_HEADER

--- a/src/space_time/space_time_block_preconditioner/space_time_block_preconditioner.h
+++ b/src/space_time/space_time_block_preconditioner/space_time_block_preconditioner.h
@@ -1,3 +1,28 @@
+//LIC// ====================================================================
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
+//LIC// at http://www.oomph-lib.org.
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
+//LIC// This library is free software; you can redistribute it and/or
+//LIC// modify it under the terms of the GNU Lesser General Public
+//LIC// License as published by the Free Software Foundation; either
+//LIC// version 2.1 of the License, or (at your option) any later version.
+//LIC// 
+//LIC// This library is distributed in the hope that it will be useful,
+//LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
+//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//LIC// Lesser General Public License for more details.
+//LIC// 
+//LIC// You should have received a copy of the GNU Lesser General Public
+//LIC// License along with this library; if not, write to the Free Software
+//LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+//LIC// 02110-1301  USA.
+//LIC// 
+//LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
+//LIC// 
+//LIC//====================================================================
 // This file was generated automatically during the make process
 // and it will be remade automatically
 #include<space_time_block_preconditioner/general_purpose_space_time_block_preconditioner.h> 

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/discontinuous_galerkin_equal_order_pressure_spacetime_fluid_traction_elements.h
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/discontinuous_galerkin_equal_order_pressure_spacetime_fluid_traction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/discontinuous_galerkin_equal_order_pressure_spacetime_navier_stokes.h
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/discontinuous_galerkin_equal_order_pressure_spacetime_navier_stokes.h
@@ -1,3 +1,28 @@
+//LIC// ====================================================================
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
+//LIC// at http://www.oomph-lib.org.
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
+//LIC// This library is free software; you can redistribute it and/or
+//LIC// modify it under the terms of the GNU Lesser General Public
+//LIC// License as published by the Free Software Foundation; either
+//LIC// version 2.1 of the License, or (at your option) any later version.
+//LIC// 
+//LIC// This library is distributed in the hope that it will be useful,
+//LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
+//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//LIC// Lesser General Public License for more details.
+//LIC// 
+//LIC// You should have received a copy of the GNU Lesser General Public
+//LIC// License along with this library; if not, write to the Free Software
+//LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+//LIC// 02110-1301  USA.
+//LIC// 
+//LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
+//LIC// 
+//LIC//====================================================================
 #include "discontinuous_galerkin_equal_order_pressure_spacetime_navier_stokes_elements.cc"
 #include "discontinuous_galerkin_equal_order_pressure_spacetime_navier_stokes_elements.h"
 #include "refineable_discontinuous_galerkin_equal_order_pressure_spacetime_navier_stokes_elements.h"

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/discontinuous_galerkin_equal_order_pressure_spacetime_navier_stokes_elements.cc
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/discontinuous_galerkin_equal_order_pressure_spacetime_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/discontinuous_galerkin_equal_order_pressure_spacetime_navier_stokes_elements.h
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/discontinuous_galerkin_equal_order_pressure_spacetime_navier_stokes_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for SpaceTimeNavierStokes elements
 #ifndef OOMPH_DISCONTINUOUS_GALERKIN_EQUAL_ORDER_PRESSURE_SPACETIME_NAVIER_STOKES_ELEMENTS_HEADER

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/discontinuous_galerkin_spacetime_fluid_traction_elements.h
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/discontinuous_galerkin_spacetime_fluid_traction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/discontinuous_galerkin_spacetime_navier_stokes.h
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/discontinuous_galerkin_spacetime_navier_stokes.h
@@ -1,3 +1,28 @@
+//LIC// ====================================================================
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
+//LIC// at http://www.oomph-lib.org.
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
+//LIC// This library is free software; you can redistribute it and/or
+//LIC// modify it under the terms of the GNU Lesser General Public
+//LIC// License as published by the Free Software Foundation; either
+//LIC// version 2.1 of the License, or (at your option) any later version.
+//LIC// 
+//LIC// This library is distributed in the hope that it will be useful,
+//LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
+//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//LIC// Lesser General Public License for more details.
+//LIC// 
+//LIC// You should have received a copy of the GNU Lesser General Public
+//LIC// License along with this library; if not, write to the Free Software
+//LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+//LIC// 02110-1301  USA.
+//LIC// 
+//LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
+//LIC// 
+//LIC//====================================================================
 #include "discontinuous_galerkin_spacetime_integral.h"
 #include "discontinuous_galerkin_spacetime_integral.cc"
 #include "discontinuous_galerkin_spacetime_navier_stokes_elements.h"

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/discontinuous_galerkin_spacetime_navier_stokes_elements.cc
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/discontinuous_galerkin_spacetime_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/discontinuous_galerkin_spacetime_navier_stokes_elements.h
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/discontinuous_galerkin_spacetime_navier_stokes_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for SpaceTimeNavierStokes elements
 #ifndef OOMPH_DISCONTINUOUS_GALERKIN_SPACETIME_NAVIER_STOKES_ELEMENTS_HEADER

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/refineable_discontinuous_galerkin_equal_order_pressure_spacetime_navier_stokes_elements.cc
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/refineable_discontinuous_galerkin_equal_order_pressure_spacetime_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/refineable_discontinuous_galerkin_equal_order_pressure_spacetime_navier_stokes_elements.h
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/refineable_discontinuous_galerkin_equal_order_pressure_spacetime_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/refineable_discontinuous_galerkin_spacetime_navier_stokes_elements.cc
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/refineable_discontinuous_galerkin_spacetime_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/refineable_discontinuous_galerkin_spacetime_navier_stokes_elements.h
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/refineable_discontinuous_galerkin_spacetime_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/refineable_spacetime_navier_stokes_elements.cc
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/refineable_spacetime_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/refineable_spacetime_navier_stokes_elements.h
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/refineable_spacetime_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/spacetime_fluid_traction_elements.h
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/spacetime_fluid_traction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/spacetime_navier_stokes.h
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/spacetime_navier_stokes.h
@@ -1,3 +1,28 @@
+//LIC// ====================================================================
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
+//LIC// at http://www.oomph-lib.org.
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
+//LIC// This library is free software; you can redistribute it and/or
+//LIC// modify it under the terms of the GNU Lesser General Public
+//LIC// License as published by the Free Software Foundation; either
+//LIC// version 2.1 of the License, or (at your option) any later version.
+//LIC// 
+//LIC// This library is distributed in the hope that it will be useful,
+//LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
+//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//LIC// Lesser General Public License for more details.
+//LIC// 
+//LIC// You should have received a copy of the GNU Lesser General Public
+//LIC// License along with this library; if not, write to the Free Software
+//LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+//LIC// 02110-1301  USA.
+//LIC// 
+//LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
+//LIC// 
+//LIC//====================================================================
 #include "spacetime_navier_stokes_elements.h" 
 #include "spacetime_navier_stokes_elements.cc" 
 #include "refineable_spacetime_navier_stokes_elements.h"

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/spacetime_navier_stokes_block_preconditionable_elements.cc
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/spacetime_navier_stokes_block_preconditionable_elements.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Non-inline functions for BlockPrecSpaceTimeNavierStokes elements
 #include "spacetime_navier_stokes_block_preconditionable_elements.h"

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/spacetime_navier_stokes_block_preconditionable_elements.h
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/spacetime_navier_stokes_block_preconditionable_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for SpaceTimeNavierStokes elements
 #ifndef OOMPH_SPACETIME_NAVIER_STOKES_BLOCK_PRECONDITIONABLE_ELEMENTS_HEADER

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/spacetime_navier_stokes_block_preconditioner.cc
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/spacetime_navier_stokes_block_preconditioner.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file
 #include "spacetime_navier_stokes_block_preconditioner.h"

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/spacetime_navier_stokes_block_preconditioner.h
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/spacetime_navier_stokes_block_preconditioner.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for SpaceTimeNavierStokes elements
 #ifndef OOMPH_SPACETIME_NAVIER_STOKES_BLOCK_PRECONDITIONERS_HEADER

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/spacetime_navier_stokes_elements.cc
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/spacetime_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/space_time/space_time_navier_stokes/archived_discretisations/spacetime_navier_stokes_elements.h
+++ b/src/space_time/space_time_navier_stokes/archived_discretisations/spacetime_navier_stokes_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for SpaceTimeNavierStokes elements
 #ifndef OOMPH_SPACETIME_NAVIER_STOKES_ELEMENTS_HEADER

--- a/src/space_time/space_time_navier_stokes/mixed_order_petrov_galerkin_space_time_block_preconditionable_elements.cc
+++ b/src/space_time/space_time_navier_stokes/mixed_order_petrov_galerkin_space_time_block_preconditionable_elements.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Non-inline functions for BlockPrecSpaceTimeNavierStokes elements
 #include "mixed_order_petrov_galerkin_space_time_block_preconditionable_elements.h"

--- a/src/space_time/space_time_navier_stokes/mixed_order_petrov_galerkin_space_time_block_preconditionable_elements.h
+++ b/src/space_time/space_time_navier_stokes/mixed_order_petrov_galerkin_space_time_block_preconditionable_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for SpaceTimeNavierStokes elements
 #ifndef OOMPH_MIXED_ORDER_PETROV_GALERKIN_SPACE_TIME_BLOCK_PRECONDITIONABLE_ELEMENTS_HEADER

--- a/src/space_time/space_time_navier_stokes/mixed_order_petrov_galerkin_space_time_fluid_traction_elements.h
+++ b/src/space_time/space_time_navier_stokes/mixed_order_petrov_galerkin_space_time_fluid_traction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/space_time/space_time_navier_stokes/mixed_order_petrov_galerkin_space_time_navier_stokes_elements.cc
+++ b/src/space_time/space_time_navier_stokes/mixed_order_petrov_galerkin_space_time_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/space_time/space_time_navier_stokes/mixed_order_petrov_galerkin_space_time_navier_stokes_elements.h
+++ b/src/space_time/space_time_navier_stokes/mixed_order_petrov_galerkin_space_time_navier_stokes_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for SpaceTimeNavierStokesMixedOrder elements
 #ifndef OOMPH_MIXED_ORDER_PETROV_GALERKIN_SPACE_TIME_NAVIER_STOKES_ELEMENTS_HEADER

--- a/src/space_time/space_time_navier_stokes/refineable_mixed_order_petrov_galerkin_space_time_navier_stokes_elements.cc
+++ b/src/space_time/space_time_navier_stokes/refineable_mixed_order_petrov_galerkin_space_time_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/space_time/space_time_navier_stokes/refineable_mixed_order_petrov_galerkin_space_time_navier_stokes_elements.h
+++ b/src/space_time/space_time_navier_stokes/refineable_mixed_order_petrov_galerkin_space_time_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/space_time/space_time_navier_stokes/space_time_navier_stokes.h
+++ b/src/space_time/space_time_navier_stokes/space_time_navier_stokes.h
@@ -1,3 +1,28 @@
+//LIC// ====================================================================
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
+//LIC// at http://www.oomph-lib.org.
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
+//LIC// This library is free software; you can redistribute it and/or
+//LIC// modify it under the terms of the GNU Lesser General Public
+//LIC// License as published by the Free Software Foundation; either
+//LIC// version 2.1 of the License, or (at your option) any later version.
+//LIC// 
+//LIC// This library is distributed in the hope that it will be useful,
+//LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
+//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//LIC// Lesser General Public License for more details.
+//LIC// 
+//LIC// You should have received a copy of the GNU Lesser General Public
+//LIC// License along with this library; if not, write to the Free Software
+//LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+//LIC// 02110-1301  USA.
+//LIC// 
+//LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
+//LIC// 
+//LIC//====================================================================
 // This file was generated automatically during the make process
 // and it will be remade automatically
 #include<space_time_navier_stokes/mixed_order_petrov_galerkin_space_time_fluid_traction_elements.h> 

--- a/src/space_time/space_time_unsteady_heat/galerkin_equal_order/refineable_space_time_unsteady_heat_elements.cc
+++ b/src/space_time/space_time_unsteady_heat/galerkin_equal_order/refineable_space_time_unsteady_heat_elements.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Source file for refineable Van der Pol elements
 #include "refineable_space_time_unsteady_heat_elements.h"

--- a/src/space_time/space_time_unsteady_heat/galerkin_equal_order/refineable_space_time_unsteady_heat_elements.h
+++ b/src/space_time/space_time_unsteady_heat/galerkin_equal_order/refineable_space_time_unsteady_heat_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for refineable unsteady heat elements
 #ifndef OOMPH_REFINEABLE_SPACE_TIME_UNSTEADY_HEAT_ELEMENTS_HEADER

--- a/src/space_time/space_time_unsteady_heat/galerkin_equal_order/space_time_unsteady_heat_block_preconditionable_elements.cc
+++ b/src/space_time/space_time_unsteady_heat/galerkin_equal_order/space_time_unsteady_heat_block_preconditionable_elements.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Non-inline functions for BlockPrecSpaceTimeUnsteadyHeat elements
 #include "space_time_unsteady_heat_block_preconditionable_elements.h"

--- a/src/space_time/space_time_unsteady_heat/galerkin_equal_order/space_time_unsteady_heat_block_preconditionable_elements.h
+++ b/src/space_time/space_time_unsteady_heat/galerkin_equal_order/space_time_unsteady_heat_block_preconditionable_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for SpaceTimeUnsteadyHeat elements
 #ifndef OOMPH_SPACE_TIME_UNSTEADY_HEAT_BLOCK_PRECONDITIONABLE_ELEMENTS_HEADER

--- a/src/space_time/space_time_unsteady_heat/galerkin_equal_order/space_time_unsteady_heat_elements.cc
+++ b/src/space_time/space_time_unsteady_heat/galerkin_equal_order/space_time_unsteady_heat_elements.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Non-inline functions for SpaceTimeUnsteadyHeat elements
 #include "space_time_unsteady_heat_elements.h"

--- a/src/space_time/space_time_unsteady_heat/galerkin_equal_order/space_time_unsteady_heat_elements.h
+++ b/src/space_time/space_time_unsteady_heat/galerkin_equal_order/space_time_unsteady_heat_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for SpaceTimeUnsteadyHeat elements
 #ifndef OOMPH_SPACE_TIME_UNSTEADY_HEAT_ELEMENTS_HEADER

--- a/src/space_time/space_time_unsteady_heat/galerkin_equal_order/space_time_unsteady_heat_equal_order_galerkin.h
+++ b/src/space_time/space_time_unsteady_heat/galerkin_equal_order/space_time_unsteady_heat_equal_order_galerkin.h
@@ -1,3 +1,28 @@
+//LIC// ====================================================================
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
+//LIC// at http://www.oomph-lib.org.
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
+//LIC// This library is free software; you can redistribute it and/or
+//LIC// modify it under the terms of the GNU Lesser General Public
+//LIC// License as published by the Free Software Foundation; either
+//LIC// version 2.1 of the License, or (at your option) any later version.
+//LIC// 
+//LIC// This library is distributed in the hope that it will be useful,
+//LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
+//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//LIC// Lesser General Public License for more details.
+//LIC// 
+//LIC// You should have received a copy of the GNU Lesser General Public
+//LIC// License along with this library; if not, write to the Free Software
+//LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+//LIC// 02110-1301  USA.
+//LIC// 
+//LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
+//LIC// 
+//LIC//====================================================================
 // This file was generated automatically during the make process
 // and it will be remade automatically
 #include<space_time_unsteady_heat/equal_order_galerkin/space_time_unsteady_heat_elements.h> 

--- a/src/space_time/space_time_unsteady_heat/galerkin_petrov_equal_order/discontinuous_galerkin_space_time_unsteady_heat_elements.cc
+++ b/src/space_time/space_time_unsteady_heat/galerkin_petrov_equal_order/discontinuous_galerkin_space_time_unsteady_heat_elements.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Non-inline functions for SpaceTimeUnsteadyHeat elements
 #include "discontinuous_galerkin_space_time_unsteady_heat_elements.h"

--- a/src/space_time/space_time_unsteady_heat/galerkin_petrov_equal_order/discontinuous_galerkin_space_time_unsteady_heat_elements.h
+++ b/src/space_time/space_time_unsteady_heat/galerkin_petrov_equal_order/discontinuous_galerkin_space_time_unsteady_heat_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for SpaceTimeUnsteadyHeat elements
 #ifndef OOMPH_DISCONTINUOUS_GALERKIN_SPACE_TIME_UNSTEADY_HEAT_ELEMENTS_HEADER

--- a/src/space_time/space_time_unsteady_heat/galerkin_petrov_equal_order/refineable_discontinuous_galerkin_space_time_unsteady_heat_elements.cc
+++ b/src/space_time/space_time_unsteady_heat/galerkin_petrov_equal_order/refineable_discontinuous_galerkin_space_time_unsteady_heat_elements.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Source file for refineable unsteady heat elements
 #include "refineable_discontinuous_galerkin_space_time_unsteady_heat_elements.h"

--- a/src/space_time/space_time_unsteady_heat/galerkin_petrov_equal_order/refineable_discontinuous_galerkin_space_time_unsteady_heat_elements.h
+++ b/src/space_time/space_time_unsteady_heat/galerkin_petrov_equal_order/refineable_discontinuous_galerkin_space_time_unsteady_heat_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for refineable unsteady heat elements
 #ifndef OOMPH_REFINEABLE_DISCONTINUOUS_GALERKIN_SPACE_TIME_UNSTEADY_HEAT_ELEMENTS_HEADER

--- a/src/space_time/space_time_unsteady_heat/galerkin_petrov_equal_order/space_time_unsteady_heat_block_preconditionable_elements.cc
+++ b/src/space_time/space_time_unsteady_heat/galerkin_petrov_equal_order/space_time_unsteady_heat_block_preconditionable_elements.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Non-inline functions for BlockPrecSpaceTimeUnsteadyHeat elements
 #include "space_time_unsteady_heat_block_preconditionable_elements.h"

--- a/src/space_time/space_time_unsteady_heat/galerkin_petrov_equal_order/space_time_unsteady_heat_block_preconditionable_elements.h
+++ b/src/space_time/space_time_unsteady_heat/galerkin_petrov_equal_order/space_time_unsteady_heat_block_preconditionable_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for SpaceTimeUnsteadyHeat elements
 #ifndef OOMPH_SPACE_TIME_UNSTEADY_HEAT_BLOCK_PRECONDITIONABLE_ELEMENTS_HEADER

--- a/src/space_time/space_time_unsteady_heat/galerkin_petrov_equal_order/space_time_unsteady_heat_equal_order_galerkin_petrov.h
+++ b/src/space_time/space_time_unsteady_heat/galerkin_petrov_equal_order/space_time_unsteady_heat_equal_order_galerkin_petrov.h
@@ -1,3 +1,28 @@
+//LIC// ====================================================================
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
+//LIC// at http://www.oomph-lib.org.
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
+//LIC// This library is free software; you can redistribute it and/or
+//LIC// modify it under the terms of the GNU Lesser General Public
+//LIC// License as published by the Free Software Foundation; either
+//LIC// version 2.1 of the License, or (at your option) any later version.
+//LIC// 
+//LIC// This library is distributed in the hope that it will be useful,
+//LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
+//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//LIC// Lesser General Public License for more details.
+//LIC// 
+//LIC// You should have received a copy of the GNU Lesser General Public
+//LIC// License along with this library; if not, write to the Free Software
+//LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+//LIC// 02110-1301  USA.
+//LIC// 
+//LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
+//LIC// 
+//LIC//====================================================================
 // This file was generated automatically during the make process
 // and it will be remade automatically
 #include<space_time_unsteady_heat/equal_order_galerkin_petrov/discontinuous_galerkin_space_time_unsteady_heat_elements.h> 

--- a/src/space_time/space_time_unsteady_heat/galerkin_petrov_mixed_order/discontinuous_galerkin_space_time_unsteady_heat_mixed_order_elements.cc
+++ b/src/space_time/space_time_unsteady_heat/galerkin_petrov_mixed_order/discontinuous_galerkin_space_time_unsteady_heat_mixed_order_elements.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Non-inline functions for SpaceTimeUnsteadyHeatMixedOrder elements
 #include "discontinuous_galerkin_space_time_unsteady_heat_mixed_order_elements.h"

--- a/src/space_time/space_time_unsteady_heat/galerkin_petrov_mixed_order/discontinuous_galerkin_space_time_unsteady_heat_mixed_order_elements.h
+++ b/src/space_time/space_time_unsteady_heat/galerkin_petrov_mixed_order/discontinuous_galerkin_space_time_unsteady_heat_mixed_order_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for SpaceTimeUnsteadyHeatMixedOrder elements
 #ifndef OOMPH_DISCONTINUOUS_GALERKIN_SPACE_TIME_UNSTEADY_HEAT_MIXED_ORDER_ELEMENTS_HEADER

--- a/src/space_time/space_time_unsteady_heat/galerkin_petrov_mixed_order/refineable_discontinuous_galerkin_space_time_unsteady_heat_mixed_order_elements.cc
+++ b/src/space_time/space_time_unsteady_heat/galerkin_petrov_mixed_order/refineable_discontinuous_galerkin_space_time_unsteady_heat_mixed_order_elements.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Source file for refineable unsteady heat elements
 #include "refineable_discontinuous_galerkin_space_time_unsteady_heat_mixed_order_elements.h"

--- a/src/space_time/space_time_unsteady_heat/galerkin_petrov_mixed_order/refineable_discontinuous_galerkin_space_time_unsteady_heat_mixed_order_elements.h
+++ b/src/space_time/space_time_unsteady_heat/galerkin_petrov_mixed_order/refineable_discontinuous_galerkin_space_time_unsteady_heat_mixed_order_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for refineable unsteady heat elements
 #ifndef OOMPH_REFINEABLE_DISCONTINUOUS_GALERKIN_SPACE_TIME_UNSTEADY_HEAT_ELEMENTS_HEADER

--- a/src/space_time/space_time_unsteady_heat/galerkin_petrov_mixed_order/space_time_unsteady_heat_mixed_order_block_preconditionable_elements.cc
+++ b/src/space_time/space_time_unsteady_heat/galerkin_petrov_mixed_order/space_time_unsteady_heat_mixed_order_block_preconditionable_elements.cc
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Non-inline functions for BlockPrecSpaceTimeUnsteadyHeat elements
 #include "space_time_unsteady_heat_mixed_order_block_preconditionable_elements.h"

--- a/src/space_time/space_time_unsteady_heat/galerkin_petrov_mixed_order/space_time_unsteady_heat_mixed_order_block_preconditionable_elements.h
+++ b/src/space_time/space_time_unsteady_heat/galerkin_petrov_mixed_order/space_time_unsteady_heat_mixed_order_block_preconditionable_elements.h
@@ -1,31 +1,27 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented,
-//LIC// multi-physics finite-element library, available
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
-//LIC//
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1182 $
-//LIC//
-//LIC// $LastChangedDate: 2016-05-20 16:50:20 +0100 (Fri, 20 May 2016) $
-//LIC//
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-//LIC//
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC//
+//LIC// 
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC//
+//LIC// 
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC//
+//LIC// 
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC//
+//LIC// 
 //LIC//====================================================================
 // Header file for SpaceTimeUnsteadyHeat elements
 #ifndef OOMPH_SPACE_TIME_UNSTEADY_HEAT_BLOCK_PRECONDITIONABLE_ELEMENTS_HEADER

--- a/src/space_time/space_time_unsteady_heat/galerkin_petrov_mixed_order/space_time_unsteady_heat_mixed_order_galerkin_petrov.h
+++ b/src/space_time/space_time_unsteady_heat/galerkin_petrov_mixed_order/space_time_unsteady_heat_mixed_order_galerkin_petrov.h
@@ -1,3 +1,28 @@
+//LIC// ====================================================================
+//LIC// This file forms part of oomph-lib, the object-oriented, 
+//LIC// multi-physics finite-element library, available 
+//LIC// at http://www.oomph-lib.org.
+//LIC// 
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+//LIC// 
+//LIC// This library is free software; you can redistribute it and/or
+//LIC// modify it under the terms of the GNU Lesser General Public
+//LIC// License as published by the Free Software Foundation; either
+//LIC// version 2.1 of the License, or (at your option) any later version.
+//LIC// 
+//LIC// This library is distributed in the hope that it will be useful,
+//LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
+//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//LIC// Lesser General Public License for more details.
+//LIC// 
+//LIC// You should have received a copy of the GNU Lesser General Public
+//LIC// License along with this library; if not, write to the Free Software
+//LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+//LIC// 02110-1301  USA.
+//LIC// 
+//LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
+//LIC// 
+//LIC//====================================================================
 // This file was generated automatically during the make process
 // and it will be remade automatically
 #include<space_time_unsteady_heat/mixed_order_galerkin_petrov/discontinuous_galerkin_space_time_unsteady_heat_mixed_order_elements.h> 

--- a/src/spherical_advection_diffusion/refineable_spherical_advection_diffusion_elements.cc
+++ b/src/spherical_advection_diffusion/refineable_spherical_advection_diffusion_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/spherical_advection_diffusion/refineable_spherical_advection_diffusion_elements.h
+++ b/src/spherical_advection_diffusion/refineable_spherical_advection_diffusion_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/spherical_advection_diffusion/spherical_advection_diffusion_elements.cc
+++ b/src/spherical_advection_diffusion/spherical_advection_diffusion_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/spherical_advection_diffusion/spherical_advection_diffusion_elements.h
+++ b/src/spherical_advection_diffusion/spherical_advection_diffusion_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/spherical_navier_stokes/refineable_spherical_navier_stokes_elements.cc
+++ b/src/spherical_navier_stokes/refineable_spherical_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/spherical_navier_stokes/refineable_spherical_navier_stokes_elements.h
+++ b/src/spherical_navier_stokes/refineable_spherical_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/spherical_navier_stokes/spherical_navier_stokes_elements.cc
+++ b/src/spherical_navier_stokes/spherical_navier_stokes_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/spherical_navier_stokes/spherical_navier_stokes_elements.h
+++ b/src/spherical_navier_stokes/spherical_navier_stokes_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/steady_axisym_advection_diffusion/steady_axisym_advection_diffusion_elements.cc
+++ b/src/steady_axisym_advection_diffusion/steady_axisym_advection_diffusion_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/steady_axisym_advection_diffusion/steady_axisym_advection_diffusion_elements.h
+++ b/src/steady_axisym_advection_diffusion/steady_axisym_advection_diffusion_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/time_harmonic_fourier_decomposed_linear_elasticity/time_harmonic_fourier_decomposed_linear_elasticity_elements.cc
+++ b/src/time_harmonic_fourier_decomposed_linear_elasticity/time_harmonic_fourier_decomposed_linear_elasticity_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/time_harmonic_fourier_decomposed_linear_elasticity/time_harmonic_fourier_decomposed_linear_elasticity_elements.h
+++ b/src/time_harmonic_fourier_decomposed_linear_elasticity/time_harmonic_fourier_decomposed_linear_elasticity_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/time_harmonic_fourier_decomposed_linear_elasticity/time_harmonic_fourier_decomposed_linear_elasticity_traction_elements.h
+++ b/src/time_harmonic_fourier_decomposed_linear_elasticity/time_harmonic_fourier_decomposed_linear_elasticity_traction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/time_harmonic_linear_elasticity/Ttime_harmonic_linear_elasticity_elements.cc
+++ b/src/time_harmonic_linear_elasticity/Ttime_harmonic_linear_elasticity_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/time_harmonic_linear_elasticity/Ttime_harmonic_linear_elasticity_elements.h
+++ b/src/time_harmonic_linear_elasticity/Ttime_harmonic_linear_elasticity_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/time_harmonic_linear_elasticity/refineable_time_harmonic_linear_elasticity_elements.cc
+++ b/src/time_harmonic_linear_elasticity/refineable_time_harmonic_linear_elasticity_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/time_harmonic_linear_elasticity/refineable_time_harmonic_linear_elasticity_elements.h
+++ b/src/time_harmonic_linear_elasticity/refineable_time_harmonic_linear_elasticity_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/time_harmonic_linear_elasticity/time_harmonic_elasticity_tensor.cc
+++ b/src/time_harmonic_linear_elasticity/time_harmonic_elasticity_tensor.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/time_harmonic_linear_elasticity/time_harmonic_elasticity_tensor.h
+++ b/src/time_harmonic_linear_elasticity/time_harmonic_elasticity_tensor.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/time_harmonic_linear_elasticity/time_harmonic_linear_elasticity_elements.cc
+++ b/src/time_harmonic_linear_elasticity/time_harmonic_linear_elasticity_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/time_harmonic_linear_elasticity/time_harmonic_linear_elasticity_elements.h
+++ b/src/time_harmonic_linear_elasticity/time_harmonic_linear_elasticity_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/time_harmonic_linear_elasticity/time_harmonic_linear_elasticity_traction_elements.h
+++ b/src/time_harmonic_linear_elasticity/time_harmonic_linear_elasticity_traction_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/unsteady_heat/Tunsteady_heat_elements.cc
+++ b/src/unsteady_heat/Tunsteady_heat_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/unsteady_heat/Tunsteady_heat_elements.h
+++ b/src/unsteady_heat/Tunsteady_heat_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/unsteady_heat/refineable_unsteady_heat_elements.cc
+++ b/src/unsteady_heat/refineable_unsteady_heat_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/unsteady_heat/refineable_unsteady_heat_elements.h
+++ b/src/unsteady_heat/refineable_unsteady_heat_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/unsteady_heat/unsteady_heat_elements.cc
+++ b/src/unsteady_heat/unsteady_heat_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/unsteady_heat/unsteady_heat_elements.h
+++ b/src/unsteady_heat/unsteady_heat_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/unsteady_heat/unsteady_heat_flux_elements.h
+++ b/src/unsteady_heat/unsteady_heat_flux_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/womersley/Twomersley_elements.cc
+++ b/src/womersley/Twomersley_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/womersley/Twomersley_elements.h
+++ b/src/womersley/Twomersley_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision: 1097 $
-//LIC//
-//LIC// $LastChangedDate: 2015-12-17 11:53:17 +0000 (Thu, 17 Dec 2015) $
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/womersley/womersley_elements.cc
+++ b/src/womersley/womersley_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/womersley/womersley_elements.h
+++ b/src/womersley/womersley_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/young_laplace/refineable_young_laplace_elements.cc
+++ b/src/young_laplace/refineable_young_laplace_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/young_laplace/refineable_young_laplace_elements.h
+++ b/src/young_laplace/refineable_young_laplace_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/young_laplace/young_laplace_contact_angle_elements.cc
+++ b/src/young_laplace/young_laplace_contact_angle_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/young_laplace/young_laplace_contact_angle_elements.h
+++ b/src/young_laplace/young_laplace_contact_angle_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/young_laplace/young_laplace_elements.cc
+++ b/src/young_laplace/young_laplace_elements.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/src/young_laplace/young_laplace_elements.h
+++ b/src/young_laplace/young_laplace_elements.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/user_drivers/jack_cool/jacks_own_code.cc
+++ b/user_drivers/jack_cool/jacks_own_code.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/user_drivers/jack_cool/jacks_poisson_code.cc
+++ b/user_drivers/jack_cool/jacks_poisson_code.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/user_drivers/joe_cool/joes_poisson_code.cc
+++ b/user_drivers/joe_cool/joes_poisson_code.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/user_src/jack_cool/hello_world.cc
+++ b/user_src/jack_cool/hello_world.cc
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public

--- a/user_src/jack_cool/hello_world.h
+++ b/user_src/jack_cool/hello_world.h
@@ -3,11 +3,7 @@
 //LIC// multi-physics finite-element library, available 
 //LIC// at http://www.oomph-lib.org.
 //LIC// 
-//LIC//    Version 1.0; svn revision $LastChangedRevision$
-//LIC//
-//LIC// $LastChangedDate$
-//LIC// 
-//LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
+//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
 //LIC// 
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
(Basically removed svn revision numbers and updated the copyright date
to end in 2021, a.k.a. now).

Can somebody have a look to see if I'm doing the right thing? I'd like these changes to be pulled back into the main repository. 