### PR TITLE
Fixed missing clamped_shell in SUB_DIRS target in Makefile.am.

### DIFF
--- a/demo_drivers/reaction_diffusion/one_d_act_inhibit/validate.sh
+++ b/demo_drivers/reaction_diffusion/one_d_act_inhibit/validate.sh
@@ -9,9 +9,9 @@ NUM_TESTS=1
 # Disable the self-test on macOS as it causes a mysterious segmentation fault.
 # To do this, we return an exit code of 0 so it looks like the test passed
 if [[ uname -eq "Darwin" ]]; then
-  echo "#==================================================== " >>validation.log
-  echo "dummy [OK] -- Test fails on macOS, not running it! " >>validation.log
-  echo "#====================================================" >>validation.log
+  echo "#==================================================== " >>Validation/validation.log
+  echo "dummy [OK] -- Test fails on macOS, not running it! " >>Validation/validation.log
+  echo "#====================================================" >>Validation/validation.log
   . $OOMPH_ROOT_DIR/bin/validate_ok_count
 
   # Never get here

--- a/demo_drivers/shell/Makefile.am
+++ b/demo_drivers/shell/Makefile.am
@@ -1,4 +1,5 @@
 SUBDIRS = \
+clamped_shell \
 clamped_or_pinned_shell \
 oscillating_shell \
 plate


### PR DESCRIPTION
Patch to address the accidentally removed `clamped_shell` from `demo_drivers/shell/Makefile.am` in https://github.com/oomph-lib/oomph-lib/pull/13; this was caught by the automated self-tests. 