### PR TITLE
Add cronjob workflow to update copyright notice every year

### DIFF
--- a/.github/workflows/update-copyright-licence.yaml
+++ b/.github/workflows/update-copyright-licence.yaml
@@ -1,0 +1,29 @@
+name: Copyright
+
+# IMPORTANT: A schedule workflow action *must* be placed on the default branch
+# of the repository. Only then will it run as scheduled. It is also placed in a
+# queue when scheduled, so it may not run exactly at the requested time.
+on:
+  # Calculated using crontab.guru. See here: https://crontab.guru/#1_0_1_1_*.
+  # Scheduled to run at 00:01 on January 1st of each year.
+  schedule:
+  - cron: '1 0 1 1 *'
+
+jobs:
+  update-copyright-notice:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repository and switch to 'development' branch
+      uses: actions/checkout@v2
+      with:
+        ref: development
+
+    - name: Update copyright notice
+      run: ./bin/update_copyright_licence_header.sh
+
+    - name: Commit changes
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_user_name: copyright-notice-cron-bot
+        commit_message: 'Automated update of copyright notices.'

--- a/bin/update_copyright_licence_header.sh
+++ b/bin/update_copyright_licence_header.sh
@@ -1,0 +1,48 @@
+#! /bin/sh
+
+# exit when any command fails
+set -e
+
+#-------------------------------------------------------------------------------
+# Shell script to perform the following steps (in the described order):
+# 1. Remove licence (all lines starting with //LIC//) from all oomph-lib *.h
+#    and *.cc files.
+# 2. Update end-year of the copyright licence in "cc_and_h_licence_block.txt".
+# 3. Apply licence prefix to all oomph-lib *.h and *.cc files.
+#-------------------------------------------------------------------------------
+
+# Find *.h and *.cc files in oomph-lib distribution (i.e. exclude external_src)
+oomph_lib_h_and_cc_files=$(find demo_drivers src user_src user_drivers self_test bin \( -name '*.h' -o -name '*.cc' \) -exec ls {} \;)
+
+# --------[ REMOVE LICENSE ]----------------------------------------------------
+
+# Remove the licence header from each source file
+for file in $oomph_lib_h_and_cc_files; do
+    echo "Delicencing:" $file
+    gawk -f bin/remove_licence.awk $file >$file.delicenced
+    mv -f $file.delicenced $file
+done
+
+# --------[ UPDATE COPYRIGHT YEAR ]---------------------------------------------
+
+current_year=$(date +"%Y")
+sed --in-place "s/Copyright (C) 2006-.* Matthias Heil and Andrew Hazel/Copyright (C) 2006-$current_year Matthias Heil and Andrew Hazel/g" bin/cc_and_h_licence_block.txt
+
+# --------[ APPLY LICENSE ]-----------------------------------------------------
+
+# Add the licence header back to delicenced files
+for file in $oomph_lib_h_and_cc_files; do
+    echo "Licencing:" $file
+    cat bin/cc_and_h_licence_block.txt $file >$file.licenced
+    gawk -f bin/remove_licence.awk $file.licenced >$file.delicenced
+    if (test $(diff $file $file.delicenced | wc -w) != 0); then
+        echo "Original and licenced/delicenced file don't match!"
+        echo "Please run bin/remove_licence.sh first."
+        echo "Filename: " $file
+        exit 1
+    else
+        echo "OK"
+        mv -f $file.licenced $file
+        rm $file.delicenced
+    fi
+done

--- a/bin/update_copyright_licence_header.sh
+++ b/bin/update_copyright_licence_header.sh
@@ -1,48 +1,32 @@
-#! /bin/sh
+#!/usr/bin/env bash
 
 # exit when any command fails
 set -e
 
 #-------------------------------------------------------------------------------
-# Shell script to perform the following steps (in the described order):
-# 1. Remove licence (all lines starting with //LIC//) from all oomph-lib *.h
-#    and *.cc files.
-# 2. Update end-year of the copyright licence in "cc_and_h_licence_block.txt".
-# 3. Apply licence prefix to all oomph-lib *.h and *.cc files.
+# Shell script to update the copyright notice of all oomph-lib-owned files.
 #-------------------------------------------------------------------------------
 
-# Find *.h and *.cc files in oomph-lib distribution (i.e. exclude external_src)
-oomph_lib_h_and_cc_files=$(find demo_drivers src user_src user_drivers self_test bin \( -name '*.h' -o -name '*.cc' \) -exec ls {} \;)
+# --------[ IDENTIFY COPYRIGHTED FILES ]----------------------------------------
 
-# --------[ REMOVE LICENSE ]----------------------------------------------------
+# Get the current filename; we need to ignore it from the search rule
+current_filename=$(basename "$0")
 
-# Remove the licence header from each source file
-for file in $oomph_lib_h_and_cc_files; do
-    echo "Delicencing:" $file
-    gawk -f bin/remove_licence.awk $file >$file.delicenced
-    mv -f $file.delicenced $file
-done
+# Search for all files containing the copyright notice
+oomph_lib_copyrighted_files=$(grep . -R -l --exclude="$current_filename" -e 'Copyright (C) 2006-' -e ' Matthias Heil and Andrew Hazel')
 
 # --------[ UPDATE COPYRIGHT YEAR ]---------------------------------------------
 
+# The end-year to update the notice to
 current_year=$(date +"%Y")
-sed --in-place "s/Copyright (C) 2006-.* Matthias Heil and Andrew Hazel/Copyright (C) 2006-$current_year Matthias Heil and Andrew Hazel/g" bin/cc_and_h_licence_block.txt
 
-# --------[ APPLY LICENSE ]-----------------------------------------------------
-
-# Add the licence header back to delicenced files
-for file in $oomph_lib_h_and_cc_files; do
-    echo "Licencing:" $file
-    cat bin/cc_and_h_licence_block.txt $file >$file.licenced
-    gawk -f bin/remove_licence.awk $file.licenced >$file.delicenced
-    if (test $(diff $file $file.delicenced | wc -w) != 0); then
-        echo "Original and licenced/delicenced file don't match!"
-        echo "Please run bin/remove_licence.sh first."
-        echo "Filename: " $file
-        exit 1
-    else
-        echo "OK"
-        mv -f $file.licenced $file
-        rm $file.delicenced
-    fi
+# Update the licence header for each file. Don't use the "-i" flag for an
+# in-place edit as this flag is not supported by the BSD version of "sed" that
+# ships with macOS
+for file in $oomph_lib_copyrighted_files; do
+    echo "Updating copyright notice for file:" $file
+    sed "s/Copyright (C) 2006-.* Matthias Heil and Andrew Hazel/Copyright (C) 2006-$current_year Matthias Heil and Andrew Hazel/g" $file >$file.updated
+    mv $file.updated $file
 done
+
+# ------------------------------------------------------------------------------

--- a/src/generic/mesh_as_geometric_object.h
+++ b/src/generic/mesh_as_geometric_object.h
@@ -1,57 +1,28 @@
 //LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented, 
-//LIC// multi-physics finite-element library, available 
+//LIC// This file forms part of oomph-lib, the object-oriented,
+//LIC// multi-physics finite-element library, available
 //LIC// at http://www.oomph-lib.org.
-//LIC// 
+//LIC//
 //LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
-//LIC// 
+//LIC//
 //LIC// This library is free software; you can redistribute it and/or
 //LIC// modify it under the terms of the GNU Lesser General Public
 //LIC// License as published by the Free Software Foundation; either
 //LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC// 
+//LIC//
 //LIC// This library is distributed in the hope that it will be useful,
 //LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
 //LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //LIC// Lesser General Public License for more details.
-//LIC// 
+//LIC//
 //LIC// You should have received a copy of the GNU Lesser General Public
 //LIC// License along with this library; if not, write to the Free Software
 //LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 //LIC// 02110-1301  USA.
-//LIC// 
+//LIC//
 //LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC// 
+//LIC//
 //LIC//====================================================================
-// LIC// ====================================================================
-// LIC// This file forms part of oomph-lib, the object-oriented,
-// LIC// multi-physics finite-element library, available
-// LIC// at http://www.oomph-lib.org.
-// LIC//
-// LIC//    Version 1.0; svn revision $LastChangedRevision$
-// LIC//
-// LIC// $LastChangedDate$
-// LIC//
-// LIC// Copyright (C) 2006-2016 Matthias Heil and Andrew Hazel
-// LIC//
-// LIC// This library is free software; you can redistribute it and/or
-// LIC// modify it under the terms of the GNU Lesser General Public
-// LIC// License as published by the Free Software Foundation; either
-// LIC// version 2.1 of the License, or (at your option) any later version.
-// LIC//
-// LIC// This library is distributed in the hope that it will be useful,
-// LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// LIC// Lesser General Public License for more details.
-// LIC//
-// LIC// You should have received a copy of the GNU Lesser General Public
-// LIC// License along with this library; if not, write to the Free Software
-// LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-// LIC// 02110-1301  USA.
-// LIC//
-// LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-// LIC//
-// LIC//====================================================================
 // Header file for a class that is used to represent a mesh
 // as a geometric object
 
@@ -126,9 +97,9 @@ class MeshAsGeomObject : public GeomObject
 
  private:
 
- 
+
  /// Helper function to actually build the thing
- void build_it(SamplePointContainerParameters* 
+ void build_it(SamplePointContainerParameters*
                sample_point_container_parameters_pt)
  {
   Mesh_pt=sample_point_container_parameters_pt->mesh_pt();
@@ -155,36 +126,36 @@ class MeshAsGeomObject : public GeomObject
                         OOMPH_CURRENT_FUNCTION,
                         OOMPH_EXCEPTION_LOCATION);
    }
-  
+
 #ifdef OOMPH_HAS_MPI
 
  // Set communicator
  Communicator_pt=Mesh_pt->communicator_pt();
- 
+
 #endif
 
 
  //Storage for the Lagrangian and Eulerian dimension
  int dim[2]={0,0};
- 
+
  //Set the Lagrangian dimension from the dimension of the first element
  //if it exists (if not the Lagrangian dimension will be zero)
- if(Mesh_pt->nelement()!=0) 
+ if(Mesh_pt->nelement()!=0)
   {
    dim[0] = Mesh_pt->finite_element_pt(0)->dim();
   }
- 
+
  //Read out the Eulerian dimension from the first node, if it exists.
  //(if not the Eulerian dimension will be zero);
  if(Mesh_pt->nnode()!=0)
   {
    dim[1] = Mesh_pt->node_pt(0)->ndim();
   }
- 
+
  // Need to do an Allreduce to ensure that the dimension is consistent
  // even when no elements are assigned to a certain processor
 #ifdef OOMPH_HAS_MPI
- 
+
 //Only a problem if the mesh has been distributed
  if(Mesh_pt->is_mesh_distributed())
   {
@@ -197,22 +168,22 @@ class MeshAsGeomObject : public GeomObject
        int dim_reduce[2];
        MPI_Allreduce(&dim,&dim_reduce,2,MPI_INT,
                      MPI_MAX,Communicator_pt->mpi_comm());
-       
-       dim[0] = dim_reduce[0]; 
+
+       dim[0] = dim_reduce[0];
        dim[1] = dim_reduce[1];
       }
     }
   }
 #endif
- 
+
  //Set the Lagrangian and Eulerian dimensions within this geometric object
  this->set_nlagrangian_and_ndim(static_cast<unsigned>(dim[0]),
                                 static_cast<unsigned>(dim[1]));
- 
- // Create temporary storage for geometric Data (don't count 
+
+ // Create temporary storage for geometric Data (don't count
  // Data twice!
  std::set<Data*> tmp_geom_data;
- 
+
  //Copy all the elements in the mesh into local storage
  //N.B. elements must be able to have a geometric object representation.
  unsigned n_sub_object = Mesh_pt->nelement();
@@ -222,12 +193,12 @@ class MeshAsGeomObject : public GeomObject
    // (Try to) cast to a finite element:
    Sub_geom_object_pt[e]=
     dynamic_cast<FiniteElement*>(Mesh_pt->element_pt(e));
-   
+
 #ifdef PARANOID
    if (Sub_geom_object_pt[e]==0)
     {
      std::ostringstream error_message;
-     error_message 
+     error_message
       << "Unable to dynamic cast element: " << std::endl
       << "into a FiniteElement: GeomObject representation is not possible\n";
      throw OomphLibError(
@@ -236,7 +207,7 @@ class MeshAsGeomObject : public GeomObject
       OOMPH_EXCEPTION_LOCATION);
     }
 #endif
-   
+
    // Add the geometric Data of each element into set
    unsigned ngeom_data=Sub_geom_object_pt[e]->ngeom_data();
    for (unsigned i=0;i<ngeom_data;i++)
@@ -244,7 +215,7 @@ class MeshAsGeomObject : public GeomObject
      tmp_geom_data.insert(Sub_geom_object_pt[e]->geom_data_pt(i));
     }
   }
- 
+
  // Now copy unique geom Data values across into vector
  unsigned ngeom=tmp_geom_data.size();
  Geom_data_pt.resize(ngeom);
@@ -255,43 +226,43 @@ class MeshAsGeomObject : public GeomObject
    Geom_data_pt[count]=*it;
    count++;
   }
- 
+
  // Build the right type of bin array
  switch (Sample_point_container_version)
   {
   case UseRefineableBinArray:
-   
+
    Sample_point_container_pt=new RefineableBinArray(sample_point_container_parameters_pt);
    break;
-   
+
   case UseNonRefineableBinArray:
-   
+
    Sample_point_container_pt=new NonRefineableBinArray(sample_point_container_parameters_pt);
    break;
-   
+
 #ifdef OOMPH_HAS_CGAL
 
   case UseCGALSamplePointContainer:
-   
+
    Sample_point_container_pt=new CGALSamplePointContainer(sample_point_container_parameters_pt);
    break;
 
 #endif
-   
+
   default:
-   
+
    oomph_info << "Sample_point_container_version = "
               << Sample_point_container_version << std::endl;
    throw OomphLibError("Sample_point_container_version",
                        OOMPH_CURRENT_FUNCTION,
-                       OOMPH_EXCEPTION_LOCATION);  
+                       OOMPH_EXCEPTION_LOCATION);
   }
  }
- 
- 
+
+
  /// \short Vector of pointers to Data items that affects the object's shape
  Vector<Data*> Geom_data_pt;
- 
+
  /// Internal storage for the elements that constitute the object
  Vector<FiniteElement*> Sub_geom_object_pt;
 
@@ -332,14 +303,14 @@ class MeshAsGeomObject : public GeomObject
  unsigned sample_point_container_version() const
   {
    return Sample_point_container_version;
-  } 
- 
+  }
+
  /// Number of elements in the underlying mesh
  unsigned nelement()
  {
   return Sub_geom_object_pt.size();
  }
- 
+
  ///\short Constructor
   MeshAsGeomObject(Mesh* const& mesh_pt)
    : GeomObject()
@@ -356,13 +327,13 @@ class MeshAsGeomObject : public GeomObject
 
 
  ///\short Constructor
-  MeshAsGeomObject(SamplePointContainerParameters* 
+  MeshAsGeomObject(SamplePointContainerParameters*
                    sample_point_container_parameters_pt)
    : GeomObject()
   {
    build_it(sample_point_container_parameters_pt);
   }
- 
+
  /// Empty Constructor
  MeshAsGeomObject() {}
 
@@ -401,8 +372,8 @@ class MeshAsGeomObject : public GeomObject
  /// argument "s" is used as the initial guess. However, this doesn't
  /// make sense here and the argument is ignored (though a warning
  /// is issued when the code is compiled in PARANOID setting)
- void locate_zeta(const Vector<double>& zeta, 
-                  GeomObject*& sub_geom_object_pt, 
+ void locate_zeta(const Vector<double>& zeta,
+                  GeomObject*& sub_geom_object_pt,
                   Vector<double>& s,
                   const bool& use_coordinate_as_initial_guess = false)
  {


### PR DESCRIPTION
**Description:**
- Automates the updating of the copyright notice headers on a yearly basis (I mentioned adding this earlier in https://github.com/oomph-lib/oomph-lib/pull/6).

**Key additions:**
- A shell script (`update_copyright_licence_header.sh`):

  - Updates the end-year in the copyright notice header (stored in `cc_and_h_licence_block.txt`) to the current year, then updates the headers of all `oomph-lib` sources.
  - Combines `apply_licence.sh` and `remove_licence.sh`, and adds functionality to change the end-year in the copyright notice line.

- A workflow script (`update-copyright-licence.yaml`):

  - Executes at 00:01 on January 1st each year.
  - Runs the shell script mentioned above on the `development` branch and commits the changes to that branch.

**Additional notes**
- The workflow will only add commits to the `development` branch.

  - I believe this is the right branch to update; if we add the changes to `main` instead, the changes will be overwritten when we merge the `development` branch in (as files on the `development` branch will have the old copyright year).
  - The `main` branch will receive the changes when we merge the changes from `development` into `main`.
  - We *could* also process and update the `main` branch but I'm not sure this is a great idea as this would create duplicate commits. However, this *would* only create duplicate commits once a year...
  - Users of the library should be able to just pull in/rebase on the added commit without issue as their branches should not have added changes to the copyright notice.
  - **I think it's worth discussing this point before merging the PR in.**

- All workflow scripts that operate on a schedule must be added to the default branch (`main` here) to work (hence why I haven't requested adding the changes to `development`).
- An unimportant point: a scheduled workflow will typically not run at the exact requested time (unlike triggered workflows), so don't expect it to. It will be placed in a queue and will be executed when resources are available.

**Minimal example:**
- I've created a minimal example [here](https://github.com/PuneetMatharu/ci-cronjob-example-update-copyright-notice). You can find the commit log [here](https://github.com/PuneetMatharu/ci-cronjob-example-update-copyright-notice/commits/main).
- To illustrate how the script works, the version associated with the "minimal example" updates the notice every hour today (29/07). Rather than setting the end-year in the notice to the current year (as this wouldn't change anything), it updates the end-year to the *current hour*.
- The workflow exists on the `main` branch but only updates the code in `src/` on the `development` branch, so switch to the commit log of the `development` branch to see the actual changes.