### PR TITLE
Explicitly demand C++11 support in build for macOS.

### DIFF
--- a/demo_drivers/poisson/two_d_poisson/two_d_poisson2_mesh.cc
+++ b/demo_drivers/poisson/two_d_poisson/two_d_poisson2_mesh.cc
@@ -1,28 +1,28 @@
-//LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented, 
-//LIC// multi-physics finite-element library, available 
-//LIC// at http://www.oomph-lib.org.
-//LIC// 
-//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
-//LIC// 
-//LIC// This library is free software; you can redistribute it and/or
-//LIC// modify it under the terms of the GNU Lesser General Public
-//LIC// License as published by the Free Software Foundation; either
-//LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC// 
-//LIC// This library is distributed in the hope that it will be useful,
-//LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
-//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-//LIC// Lesser General Public License for more details.
-//LIC// 
-//LIC// You should have received a copy of the GNU Lesser General Public
-//LIC// License along with this library; if not, write to the Free Software
-//LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-//LIC// 02110-1301  USA.
-//LIC// 
-//LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC// 
-//LIC//====================================================================
+// LIC// ====================================================================
+// LIC// This file forms part of oomph-lib, the object-oriented,
+// LIC// multi-physics finite-element library, available
+// LIC// at http://www.oomph-lib.org.
+// LIC//
+// LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+// LIC//
+// LIC// This library is free software; you can redistribute it and/or
+// LIC// modify it under the terms of the GNU Lesser General Public
+// LIC// License as published by the Free Software Foundation; either
+// LIC// version 2.1 of the License, or (at your option) any later version.
+// LIC//
+// LIC// This library is distributed in the hope that it will be useful,
+// LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// LIC// Lesser General Public License for more details.
+// LIC//
+// LIC// You should have received a copy of the GNU Lesser General Public
+// LIC// License along with this library; if not, write to the Free Software
+// LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+// LIC// 02110-1301  USA.
+// LIC//
+// LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
+// LIC//
+// LIC//====================================================================
 // Mesh builder: This builds the mesh with a specific element
 // so that the mesh sources don't have to be re-compiled over
 // and over again in the driver code... Useful strategy if
@@ -37,10 +37,8 @@
 // templated sources)
 #include "meshes/simple_rectangular_quadmesh.h"
 
-using namespace oomph;
-
-// Force build of specific mesh
-template class SimpleRectangularQuadMesh<QPoissonElement<2,3> >;
-
-
-
+namespace oomph
+{
+  // Force build of specific mesh
+  template class SimpleRectangularQuadMesh<QPoissonElement<2, 3>>;
+} // namespace oomph

--- a/demo_drivers/solid/simple_shear/Makefile.am
+++ b/demo_drivers/solid/simple_shear/Makefile.am
@@ -7,21 +7,21 @@ check_PROGRAMS=simple_shear refineable_simple_shear
 # Sources for executable
 simple_shear_SOURCES = simple_shear.cc precompiled_mesh.cc
 
-# Required libraries: 
+# Required libraries:
 # $(FLIBS) is included in case the solver involves fortran sources.
 simple_shear_LDADD = -L@libdir@ -lsolid -lconstitutive -lgeneric \
-                    $(EXTERNAL_LIBS) $(FLIBS)
+					$(EXTERNAL_LIBS) $(FLIBS)
 
 # Sources for executable
 refineable_simple_shear_SOURCES = refineable_simple_shear.cc precompiled_mesh.cc
 
-# Required libraries: 
+# Required libraries:
 # $(FLIBS) is included in case the solver involves fortran sources.
 refineable_simple_shear_LDADD = -L@libdir@ -lsolid -lconstitutive -lgeneric \
-                    $(EXTERNAL_LIBS) $(FLIBS)
+					$(EXTERNAL_LIBS) $(FLIBS)
 
 #Automake doesn't have an easy way to make without optimisation
 #This is the automake generated option without CXX and CPP flags
 precompiled_mesh.o : precompiled_mesh.cc
-	$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(AM_CXXFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $<
+	$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $<
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Po

--- a/non_interactive_autogen.sh
+++ b/non_interactive_autogen.sh
@@ -42,7 +42,7 @@ run_self_tests=0
 while getopts ":hrd:c:b:j:skonS" opt; do
     case $opt in
 
-        S) 
+        S)
             echo "Will run self tests (serially) at end of build"
             run_self_tests=1
             ;;
@@ -105,7 +105,7 @@ while getopts ":hrd:c:b:j:skonS" opt; do
     esac
 done
 
-# and for build dir 
+# and for build dir
 if [[ $build_dir == "" ]]; then
     build_dir=${oomph_root}/build
 fi
@@ -289,7 +289,7 @@ EOF
 # autoconf and configure.
 we_will_need_libtool_for_dealing_with_added_directories=false
 touch "$confdir/makefile_list"
-if ! diff -q "$confdir/new_makefile_list" "$confdir/makefile_list" > /dev/null 2>&1; 
+if ! diff -q "$confdir/new_makefile_list" "$confdir/makefile_list" > /dev/null 2>&1;
 then
     echo "New/removed directories detected and $confdir/makefile_list updated,"
     echo "./configure will be rerun automatically by make."
@@ -342,7 +342,7 @@ echo "...back from checking linking type for trilinos: "$link_type
 extra_flags_for_linking_against_shared_libraries=""
 if [ "$link_type" == "dynamic" ]; then
     echo "doing dynamic linking for trilinos"
-    # The additional flags needed to link against shared libraries. 
+    # The additional flags needed to link against shared libraries.
     # PM: When building shared third-party libraries, we need to ensure that we
     # can access their code irregardless of the load address. Such code is
     # referred to as position independent code (PIC). To make sure the code is
@@ -366,6 +366,14 @@ do
     InsertExtraFlags "$temporary_configure_options_file" "$i_flag"
 done
 
+# Have to explicitly demand C++11 on macOS; not necessary on Linux
+if [[ $(uname) == "Darwin" ]]; then
+    echo "You're on macOS so I'm going to explicitly add the flag for C++11!"
+
+    # Add the flags required for enabling C++11 features
+    InsertFlagsForEnablingC++11 "$temporary_configure_options_file"
+fi
+
 # Read the options from the files and convert them into a single one-line string
 new_configure_options=$(ProcessOptionsFile < "$temporary_configure_options_file")
 old_configure_options=$(ProcessOptionsFile < config/configure_options/current)
@@ -376,10 +384,10 @@ if [[ "$new_configure_options" != "$old_configure_options" ||
 
     # Check that the options are in the correct order
     configure_options_are_ok="$(CheckOptions $temporary_configure_options_file)"
-    
+
     # Kill the temporary file
     rm -f "$temporary_configure_options_file"
-    
+
     # Check if the options are okay
     if test "$configure_options_are_ok" != ""; then
 
@@ -390,11 +398,11 @@ if [[ "$new_configure_options" != "$old_configure_options" ||
         echo $configure_options_are_ok 1>&2
         echo  1>&2
         echo "===============================================================" 1>&2
-        
+
         # Failed
         exit 4
     fi
-        
+
     # Slight problem here: if we change the options and add a new
     # driver at the same time then configure will end up being re-run twice.
     # Don't think there's anything we can do about it
@@ -410,9 +418,9 @@ if [[ "$new_configure_options" != "$old_configure_options" ||
 
     # Finally run configure itself to convert "Makefile.in"s into "Makefile"s
     echo
-    echo "Running ./configure --prefix $build_dir $new_configure_options $extra_configure_options " 
+    echo "Running ./configure --prefix $build_dir $new_configure_options $extra_configure_options "
     echo
-    /bin/sh -c "./configure --prefix $build_dir $new_configure_options $extra_configure_options " 
+    /bin/sh -c "./configure --prefix $build_dir $new_configure_options $extra_configure_options "
 
     # Test that the mpi commands work with these configure options
     # (automatically passes if no variable MPI_RUN_COMMAND in makefile).
@@ -425,7 +433,7 @@ fi
 
 # If the temporary file still exists
 if [ -f "$temporary_configure_options_file" ]
-then  
+then
     # Kill it
     rm -f "$temporary_configure_options_file"
 fi
@@ -456,7 +464,7 @@ echo " "
 echo "Running make with make_options:"
 echo " "
 echo $make_options
-echo " " 
+echo " "
 
 make $make_options
 
@@ -468,7 +476,7 @@ echo " "
 echo "Running make install with make_options"
 echo " "
 echo $make_options
-echo " " 
+echo " "
 
 make $make_options install
 


### PR DESCRIPTION
## Description of change
<!-- Please provide a description of the change here. -->

Explicitly demands C++11 support on macOS, fixes the issue with Makefile recipe in `simple_shear` demo-driver, and fixes the issue with the explicit instantiation of `SimpleRectangularQuadMesh` in `poisson/two_d_poisson/two_d_poisson2_mesh.cc`.

**Note:**  Unlike Ubuntu, the compiler on macOS does not appear to automatically assume C++11 as the standard, requiring the compiler flag to be specified explicitly.

## Affected components
<!-- Please provide affected components. -->

- `bin/autogen_helpers.sh`: 
  - Added the function `InsertFlagsForEnablingC++11()` to sneak `-std=c++11` into the `CXXFLAGS` variable inside the user's configuration file to explicitly demand C++11 support.

- `non_interactive_autogen.sh`: 
  - Updated to call `InsertFlagsForEnablingC++11()` on macOS.

- `demo_drivers/solid/simple_shear/Makefile.am`: 
  - Updated custom Makefile recipe for `precompiled_mesh.o` to include the contents of `$(CXXFLAGS)` (to ensure that the C++11 support gets added on macOS).

  - **NOTE:** It appears that the aim of this recipe was to avoid adding optimisation (see lines below) without including `CXXFLAGS` but it might also go against the grain to explicitly provide the `-std=c++11` flag in there. 

  - Link to relevant lines: https://github.com/oomph-lib/oomph-lib/blob/43ade517cef185a8097591f8dcfbc7afa93710de/demo_drivers/solid/simple_shear/Makefile.am#L23-L27

  - **Q: Is it okay to keep `CXXFLAGS` in there?**

- `poisson/two_d_poisson/two_d_poisson2_mesh.cc`:
  - Updated to define the explicit instantiation *inside* the `oomph` namespace.

## Links to self-test workflows
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [**Ubuntu tests**](https://github.com/PuneetMatharu/oomph-lib/actions/runs/1138498968)
- [**macOS tests**](https://github.com/PuneetMatharu/oomph-lib/actions/runs/1138498971)

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] The Ubuntu tests pass.
- [x] The macOS tests pass.
