### PR TITLE
Add parallelisation to build and validation in self-test workflows

### DIFF
--- a/.github/workflows/self-tests-macos.yaml
+++ b/.github/workflows/self-tests-macos.yaml
@@ -20,7 +20,7 @@ jobs:
           && ( export LC_ALL=C; sort -o config/configure_options/default config/configure_options/default )
 
       - name: Build
-        run: ./non_interactive_autogen.sh -s -j$(nproc)
+        run: ./non_interactive_autogen.sh -s -j$(sysctl -n hw.logicalcpu)
 
       - name: Validate
         run: ./bin/parallel_self_test.py

--- a/.github/workflows/self-tests-macos.yaml
+++ b/.github/workflows/self-tests-macos.yaml
@@ -6,26 +6,27 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-    - name: Check out repository
-      uses: actions/checkout@v2
+      - name: Check out repository
+        uses: actions/checkout@v2
 
-    - name: Install requirements
-      run: |
-        brew install make automake libtool autoconf doxygen
-        brew reinstall gfortran
+      - name: Install requirements
+        run: |
+          brew install make automake libtool autoconf doxygen
+          brew reinstall gfortran
 
-    - name: Extra config
-      run: printf '%s\n' '--enable-suppress-cgal-build --disable-shared' >> config/configure_options/default \
-           && ( export LC_ALL=C; sort -o config/configure_options/default config/configure_options/default )
+      - name: Extra config
+        run:
+          printf '%s\n' '--enable-suppress-cgal-build --disable-shared' >> config/configure_options/default \
+          && ( export LC_ALL=C; sort -o config/configure_options/default config/configure_options/default )
 
-    - name: Build
-      run: ./non_interactive_autogen.sh -s -j6
+      - name: Build
+        run: ./non_interactive_autogen.sh -s -j$(nproc)
 
-    - name: Validate
-      run: ./bin/parallel_self_test.py
+      - name: Validate
+        run: ./bin/parallel_self_test.py
 
-    - name: Upload validation log file
-      uses: actions/upload-artifact@v2
-      with:
-        name: macos-latest validation log
-        path: ./validation.log
+      - name: Upload validation log file
+        uses: actions/upload-artifact@v2
+        with:
+          name: macos-latest validation log
+          path: ./validation.log

--- a/.github/workflows/self-tests-macos.yaml
+++ b/.github/workflows/self-tests-macos.yaml
@@ -6,18 +6,24 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - name: Check out repository
+      uses: actions/checkout@v2
+
     - name: Install requirements
       run: |
         brew install make automake libtool autoconf doxygen
         brew reinstall gfortran
+
     - name: Extra config
       run: printf '%s\n' '--enable-suppress-cgal-build --disable-shared' >> config/configure_options/default \
            && ( export LC_ALL=C; sort -o config/configure_options/default config/configure_options/default )
+
     - name: Build
-      run: ./non_interactive_autogen.sh -s
+      run: ./non_interactive_autogen.sh -s -j6
+
     - name: Validate
-      run: make check -k -s
+      run: ./bin/parallel_self_test.py
+
     - name: Upload validation log file
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/self-tests-ubuntu.yaml
+++ b/.github/workflows/self-tests-ubuntu.yaml
@@ -12,7 +12,7 @@ jobs:
       run: sudo apt-get install make automake libtool libtool-bin autoconf doxygen gfortran g++
 
     - name: Build
-      run: ./non_interactive_autogen.sh -s -j2
+      run: ./non_interactive_autogen.sh -s -j$(nproc)
 
     - name: Validate
       run: ./bin/parallel_self_test.py

--- a/.github/workflows/self-tests-ubuntu.yaml
+++ b/.github/workflows/self-tests-ubuntu.yaml
@@ -7,12 +7,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
     - name: Install requirements
       run: sudo apt-get install make automake libtool libtool-bin autoconf doxygen gfortran g++
+
     - name: Build
-      run: ./non_interactive_autogen.sh -s
+      run: ./non_interactive_autogen.sh -s -j2
+
     - name: Validate
-      run: make check -k -s
+      run: ./bin/parallel_self_test.py
+
     - name: Upload validation log file
       uses: actions/upload-artifact@v2
       with:

--- a/bin/parallel_self_test.py
+++ b/bin/parallel_self_test.py
@@ -22,7 +22,6 @@
 # but this is easy to change by modifying e.g. check_if_mpi_driver(...)
 
 
-
 # Some python 3 compatability. With these imports most scripts should work
 # in both python 2.7 and python 3.x.
 from __future__ import print_function
@@ -69,6 +68,7 @@ class Colours:
         self.TestFail = ''
         self.Endc = ''
 
+
 # Make a GLOBAL colours object to tell print functions how to make things
 # pretty. Easier to make it global because we want to be able to disable it
 # from inside main() without passing around a Colours object all over the
@@ -76,6 +76,8 @@ class Colours:
 COLOURS = Colours()
 
 # Various functions for printing with pretty colours
+
+
 def highlight(directorypath):
     return os.path.dirname(directorypath) + "/" + COLOURS.Header + \
         os.path.basename(directorypath) + COLOURS.Endc
@@ -135,7 +137,7 @@ def variable_from_makefile(variable_name, makefile_path="Makefile"):
     # the pwd, which dirname fails a bit on...
     makefile_dir = os.path.dirname(makefile_path)
     if makefile_dir == "":
-        makefile_dir = pjoin('.','')
+        makefile_dir = pjoin('.', '')
 
     # Run make using both a real makefile and a dummy one we are about to
     # create. Call the "print-var" command which will be in the dummy
@@ -146,7 +148,8 @@ def variable_from_makefile(variable_name, makefile_path="Makefile"):
 
     # Send in a dummy makefile with a print command, output should be the
     # value of the variable.
-    stdout, _ = process.communicate(("print-var:; @echo $(" + variable_name + ")").encode())
+    stdout, _ = process.communicate(
+        ("print-var:; @echo $(" + variable_name + ")").encode())
 
     # Check that make exited with a success code (0)
     returncode = process.wait()
@@ -180,6 +183,7 @@ def get_oomph_root():
 # Validation functions
 # ============================================================
 
+
 def find_validate_dirs(base_dirs):
     """Construct a list of validation directories by searching for
     validate.sh scripts."""
@@ -202,16 +206,22 @@ def dispatch_dir(dirname, features, **kwargs):
     # run the check.
     for feature in features:
         if not feature['have_feature']:
-           if feature['check_driver_function'](dirname):
-               missing_feature_message(dirname, feature['feature_name'])
-               return
+            if feature['check_driver_function'](dirname):
+                missing_feature_message(dirname, feature['feature_name'])
+                return
 
     make_check_in_dir(dirname, **kwargs)
 
 
 # Functions for checking if a test needs a certain feature
-def check_if_mpi_driver(d): return "mpi" in d
-def check_if_arpack_driver(d): return "eigenproblems" in d
+def check_if_mpi_driver(d):
+    return "mpi" in d
+
+
+def check_if_arpack_driver(d):
+    return "eigenproblems" in d
+
+
 def check_if_hlib_driver(d):
     # hlib is in "oomphlib", so take it out in case people use dirs called
     # oomphlib with no -.
@@ -233,7 +243,6 @@ def make_check_in_dir(directory, just_build=False):
     sure the folder exists.
     """
 
-
     # Write make output into a file in test rootdir (in case Validation dir
     # doesn't exist yet).
     tracefile_path = pjoin(directory, "make_check_output")
@@ -250,9 +259,9 @@ def make_check_in_dir(directory, just_build=False):
         build_return = subp.call(['make', 'check', '--silent',
                                   'LIBTOOLFLAGS=--silent',
                                   'TESTS_ENVIRONMENT=true'],
-                                  cwd = directory,
-                                  stdout=tracefile,
-                                  stderr=subp.STDOUT)
+                                 cwd=directory,
+                                 stdout=tracefile,
+                                 stderr=subp.STDOUT)
 
         # If it failed then return a build failure immediately
         if build_return != 0:
@@ -266,7 +275,7 @@ def make_check_in_dir(directory, just_build=False):
             # Run make check (runs the actual test)
             test_result = subp.call(['make', 'check', '--silent',
                                     'LIBTOOLFLAGS=--silent'],
-                                    cwd = directory,
+                                    cwd=directory,
                                     stdout=tracefile,
                                     stderr=subp.STDOUT)
 
@@ -282,17 +291,18 @@ def make_check_in_dir(directory, just_build=False):
     # Validation dir should exist now. Move the output file there if so,
     # otherwise issue a warning.
     if not os.path.isdir(os.path.dirname(final_tracefile_path)):
-        sys.stderr.write("Warning: no Validation directory in "+directory
-                         +" so I couldn't put make_check_output in there\n")
+        sys.stderr.write("WARNING: no Validation directory in "+directory
+                         + " so I couldn't put make_check_output in there\n")
         sys.stderr.flush()
     else:
         os.rename(tracefile_path, final_tracefile_path)
-
 
     if test_result == 0:
         check_success_message(directory)
         return
     else:
+        with open(tracefile_path, 'r') as tracefile:
+            print(tracefile.read())
         check_fail_message(directory)
         return
 
@@ -331,44 +341,61 @@ def main():
 
         # Don't mess up my formating in the help message
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        )
+    )
 
     # make uses -C for "run make in this directory" so copy it
-    parser.add_argument('-C', dest='oomph_root',
-                        help='Set the root directory of oomph-lib, by default try to \
-    extract it from a Makefile.')
+    parser.add_argument(
+        '-C', dest='oomph_root',
+        help='Set the root directory of oomph-lib, by default try to extract it from a Makefile.'
+    )
 
-    parser.add_argument('-a', action='store_true', dest='makeclean',
-                        help='Run make clean on test folders before starting.')
+    parser.add_argument(
+        '-a', action='store_true', dest='makeclean',
+        help='Run make clean on test folders before starting.'
+    )
 
-    parser.add_argument('-l', '--base-dir', action='append', dest='base_dirs',
-                        default=[],
-                        help='Specify directories relative to the root to (recursively)'
-                        + ' look for tests in.'
-                        + ' Uses "demo_drivers" and "self_test" by default.')
+    parser.add_argument(
+        '-l', '--base-dir', action='append', dest='base_dirs',
+        default=[],
+        help='Specify directories relative to the root to (recursively)'
+        + ' look for tests in.'
+        + ' Uses "demo_drivers" and "self_test" by default.'
+    )
 
-    parser.add_argument('-L', '--base-dirs-file', action='append', dest='base_dirs_files',
-                        default=[],
-                        help='Specify files containing a list of directories relative to the root to (recursively) look for tests in. Uses "demo_drivers" and "self_test" by default.')
+    parser.add_argument(
+        '-L', '--base-dirs-file', action='append', dest='base_dirs_files',
+        default=[],
+        help='Specify files containing a list of directories relative to the root to (recursively) look for tests in. Uses "demo_drivers" and "self_test" by default.'
+    )
 
-    parser.add_argument('-j', '-n', dest='ncores',
-                        help='Specifiy how many cores should be used altogether \
+    parser.add_argument(
+        '-j', '-n', dest='ncores',
+        help='Specifiy how many cores should be used altogether \
                         (taking mpi runs into account). By default use all cores.',
-                        default=multiprocessing.cpu_count())
+        default=multiprocessing.cpu_count()
+    )
 
-    parser.add_argument('--no-colour', action='store_true',
-                        help='Disable colours in output.')
+    parser.add_argument(
+        '--no-colour', action='store_true',
+        help='Disable colours in output.'
+    )
 
-    parser.add_argument('--check-scripts', action='store_true',
-                        help='Check all the validate.sh scripts using a simple '
-                        + 'regex to make sure that they set an exit status.')
+    parser.add_argument(
+        '--check-scripts', action='store_true',
+        help='Check all the validate.sh scripts using a simple '
+        + 'regex to make sure that they set an exit status.'
+    )
 
-    parser.add_argument('--just-build', action='store_true',
-                        help="Only build the tests, don't run them")
+    parser.add_argument(
+        '--just-build', action='store_true',
+        help="Only build the tests, don't run them"
+    )
 
-    parser.add_argument('--serial-mode', action='store_true',
-                        help='Run the script without parallelism (for debugging'
-                        +' purposes).')
+    parser.add_argument(
+        '--serial-mode', action='store_true',
+        help='Run the script without parallelism (for debugging'
+        + ' purposes).'
+    )
 
     args = parser.parse_args()
 
@@ -380,63 +407,62 @@ def main():
     if args.oomph_root is None:
         args.oomph_root = get_oomph_root()
 
-
     # If we requested just checking the validate.sh scripts instead of
     # running the tests
     if args.check_scripts:
         # Grep for some way of returning an exit status in validate.sh scripts,
         # print out those that don't contain one.
-        print("Checking validate.sh scripts. Any scripts printed below do not set\n"+
-              "their exit status properly and so the results cannot be correctly\n"+
+        print("Checking validate.sh scripts. Any scripts printed below do not set\n" +
+              "their exit status properly and so the results cannot be correctly\n" +
               "reported by this script.")
         print("Look in other validate scripts to see how to fix this.")
         subp.call('find -name "validate.sh" | xargs grep -i -L "^exit \|^set -o errexit"',
                   shell=True, cwd=args.oomph_root)
         return 0
 
-
     # Figure out if we have various features
     # ============================================================
 
-    #??ds there MUST be a way to detect this somehow...
+    # ??ds there MUST be a way to detect this somehow...
     have_arpack = False
 
     # Find out if we have mpi by looking for "OOMPH_HAS_MPI" in flags in
     # Makefile.
     have_mpi = "OOMPH_HAS_MPI" in \
-      variable_from_makefile("AM_CPPFLAGS", pjoin(args.oomph_root, "Makefile"))
+        variable_from_makefile(
+            "AM_CPPFLAGS", pjoin(args.oomph_root, "Makefile"))
 
     # Similarly for hlib
     have_hlib = "OOMPH_HAS_HLIB" in \
-      variable_from_makefile("AM_CPPFLAGS", pjoin(args.oomph_root, "Makefile"))
-
+        variable_from_makefile(
+            "AM_CPPFLAGS", pjoin(args.oomph_root, "Makefile"))
 
     # List of possible features. Each one must contain: "feature_name",
     # check_driver_function--a function to find out if a directory requires
     # this feature and have_feature--a boolean for if we have this feature
     # or not.
-    oomph_features =\
-      ([ {'feature_name' : "arpack",
-          'check_driver_function' : check_if_arpack_driver,
-          'have_feature' : have_arpack
-       },
-
-       {'feature_name' : "mpi",
-        'check_driver_function' : check_if_mpi_driver,
-        'have_feature' : have_mpi
+    oomph_features = ([
+        {
+            'feature_name': "arpack",
+            'check_driver_function': check_if_arpack_driver,
+            'have_feature': have_arpack
         },
-
-       {'feature_name' : "hlib",
-        'check_driver_function' : check_if_hlib_driver,
-        'have_feature' : have_hlib
+        {
+            'feature_name': "mpi",
+            'check_driver_function': check_if_mpi_driver,
+            'have_feature': have_mpi
+        },
+        {
+            'feature_name': "hlib",
+            'check_driver_function': check_if_hlib_driver,
+            'have_feature': have_hlib,
         }
-        ])
+    ])
 
     # Print our findings:
     print("\nChecked for the following features:")
     for feature in oomph_features:
         print("    ", feature['feature_name'], ":", feature['have_feature'])
-
 
     # Gather directory lists etc.
     # ============================================================
@@ -447,7 +473,7 @@ def main():
         with open(dirs_file_name) as f:
             # Strip whitespace and ignore blank lines
             base_dirs = base_dirs + \
-              [l.strip() for l in f.readlines() if l.strip() != ""]
+                [l.strip() for l in f.readlines() if l.strip() != ""]
 
     # If there are no base dirs given in either list then use defaults:
     if len(base_dirs) == 0:
@@ -455,12 +481,11 @@ def main():
 
     # Convert to absolute paths
     abs_base_dirs = [os.path.abspath(os.path.join(args.oomph_root, b))
-                      for b in base_dirs]
+                     for b in base_dirs]
 
     print("\nLooking for validate.sh scripts in directories:")
     pprint.pprint(abs_base_dirs)
     print()
-
 
     # Run tests
     # =========================================================================
@@ -472,8 +497,8 @@ def main():
             # Make clean in "directory" with stdout thrown away.
             subp.check_call(['make', 'clean', '-k',
                              '-j', str(args.ncores)],
-                             stdout = open(os.devnull, 'w'),
-                             cwd = directory)
+                            stdout=open(os.devnull, 'w'),
+                            cwd=directory)
 
     # Construct a list of validation directories
     validation_dirs = find_validate_dirs(abs_base_dirs)
@@ -482,7 +507,7 @@ def main():
     f = pt(dispatch_dir, features=oomph_features, just_build=args.just_build)
 
     if args.serial_mode:
-        list(map(f, validation_dirs)) # list forces evaluation of the map
+        list(map(f, validation_dirs))  # list forces evaluation of the map
     else:
         # Run it in parallel.
         Pool(processes=int(args.ncores)).map(f, validation_dirs, 1)

--- a/demo_drivers/poisson/two_d_poisson/two_d_poisson2_mesh.cc
+++ b/demo_drivers/poisson/two_d_poisson/two_d_poisson2_mesh.cc
@@ -1,28 +1,28 @@
-//LIC// ====================================================================
-//LIC// This file forms part of oomph-lib, the object-oriented, 
-//LIC// multi-physics finite-element library, available 
-//LIC// at http://www.oomph-lib.org.
-//LIC// 
-//LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
-//LIC// 
-//LIC// This library is free software; you can redistribute it and/or
-//LIC// modify it under the terms of the GNU Lesser General Public
-//LIC// License as published by the Free Software Foundation; either
-//LIC// version 2.1 of the License, or (at your option) any later version.
-//LIC// 
-//LIC// This library is distributed in the hope that it will be useful,
-//LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
-//LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-//LIC// Lesser General Public License for more details.
-//LIC// 
-//LIC// You should have received a copy of the GNU Lesser General Public
-//LIC// License along with this library; if not, write to the Free Software
-//LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-//LIC// 02110-1301  USA.
-//LIC// 
-//LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
-//LIC// 
-//LIC//====================================================================
+// LIC// ====================================================================
+// LIC// This file forms part of oomph-lib, the object-oriented,
+// LIC// multi-physics finite-element library, available
+// LIC// at http://www.oomph-lib.org.
+// LIC//
+// LIC// Copyright (C) 2006-2021 Matthias Heil and Andrew Hazel
+// LIC//
+// LIC// This library is free software; you can redistribute it and/or
+// LIC// modify it under the terms of the GNU Lesser General Public
+// LIC// License as published by the Free Software Foundation; either
+// LIC// version 2.1 of the License, or (at your option) any later version.
+// LIC//
+// LIC// This library is distributed in the hope that it will be useful,
+// LIC// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// LIC// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// LIC// Lesser General Public License for more details.
+// LIC//
+// LIC// You should have received a copy of the GNU Lesser General Public
+// LIC// License along with this library; if not, write to the Free Software
+// LIC// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+// LIC// 02110-1301  USA.
+// LIC//
+// LIC// The authors may be contacted at oomph-lib@maths.man.ac.uk.
+// LIC//
+// LIC//====================================================================
 // Mesh builder: This builds the mesh with a specific element
 // so that the mesh sources don't have to be re-compiled over
 // and over again in the driver code... Useful strategy if
@@ -37,10 +37,8 @@
 // templated sources)
 #include "meshes/simple_rectangular_quadmesh.h"
 
-using namespace oomph;
-
-// Force build of specific mesh
-template class SimpleRectangularQuadMesh<QPoissonElement<2,3> >;
-
-
-
+namespace oomph
+{
+  // Force build of specific mesh
+  template class SimpleRectangularQuadMesh<QPoissonElement<2, 3>>;
+} // namespace oomph

--- a/demo_drivers/solid/simple_shear/Makefile.am
+++ b/demo_drivers/solid/simple_shear/Makefile.am
@@ -7,21 +7,21 @@ check_PROGRAMS=simple_shear refineable_simple_shear
 # Sources for executable
 simple_shear_SOURCES = simple_shear.cc precompiled_mesh.cc
 
-# Required libraries: 
+# Required libraries:
 # $(FLIBS) is included in case the solver involves fortran sources.
 simple_shear_LDADD = -L@libdir@ -lsolid -lconstitutive -lgeneric \
-                    $(EXTERNAL_LIBS) $(FLIBS)
+					$(EXTERNAL_LIBS) $(FLIBS)
 
 # Sources for executable
 refineable_simple_shear_SOURCES = refineable_simple_shear.cc precompiled_mesh.cc
 
-# Required libraries: 
+# Required libraries:
 # $(FLIBS) is included in case the solver involves fortran sources.
 refineable_simple_shear_LDADD = -L@libdir@ -lsolid -lconstitutive -lgeneric \
-                    $(EXTERNAL_LIBS) $(FLIBS)
+					$(EXTERNAL_LIBS) $(FLIBS)
 
 #Automake doesn't have an easy way to make without optimisation
 #This is the automake generated option without CXX and CPP flags
 precompiled_mesh.o : precompiled_mesh.cc
-	$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(AM_CXXFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $<
+	$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $<
 	mv -f $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Po

--- a/non_interactive_autogen.sh
+++ b/non_interactive_autogen.sh
@@ -42,7 +42,7 @@ run_self_tests=0
 while getopts ":hrd:c:b:j:skonS" opt; do
     case $opt in
 
-        S) 
+        S)
             echo "Will run self tests (serially) at end of build"
             run_self_tests=1
             ;;
@@ -105,7 +105,7 @@ while getopts ":hrd:c:b:j:skonS" opt; do
     esac
 done
 
-# and for build dir 
+# and for build dir
 if [[ $build_dir == "" ]]; then
     build_dir=${oomph_root}/build
 fi
@@ -289,7 +289,7 @@ EOF
 # autoconf and configure.
 we_will_need_libtool_for_dealing_with_added_directories=false
 touch "$confdir/makefile_list"
-if ! diff -q "$confdir/new_makefile_list" "$confdir/makefile_list" > /dev/null 2>&1; 
+if ! diff -q "$confdir/new_makefile_list" "$confdir/makefile_list" > /dev/null 2>&1;
 then
     echo "New/removed directories detected and $confdir/makefile_list updated,"
     echo "./configure will be rerun automatically by make."
@@ -342,7 +342,7 @@ echo "...back from checking linking type for trilinos: "$link_type
 extra_flags_for_linking_against_shared_libraries=""
 if [ "$link_type" == "dynamic" ]; then
     echo "doing dynamic linking for trilinos"
-    # The additional flags needed to link against shared libraries. 
+    # The additional flags needed to link against shared libraries.
     # PM: When building shared third-party libraries, we need to ensure that we
     # can access their code irregardless of the load address. Such code is
     # referred to as position independent code (PIC). To make sure the code is
@@ -366,6 +366,14 @@ do
     InsertExtraFlags "$temporary_configure_options_file" "$i_flag"
 done
 
+# Have to explicitly demand C++11 on macOS; not necessary on Linux
+if [[ $(uname) == "Darwin" ]]; then
+    echo "You're on macOS so I'm going to explicitly add the flag for C++11!"
+
+    # Add the flags required for enabling C++11 features
+    InsertFlagsForEnablingC++11 "$temporary_configure_options_file"
+fi
+
 # Read the options from the files and convert them into a single one-line string
 new_configure_options=$(ProcessOptionsFile < "$temporary_configure_options_file")
 old_configure_options=$(ProcessOptionsFile < config/configure_options/current)
@@ -376,10 +384,10 @@ if [[ "$new_configure_options" != "$old_configure_options" ||
 
     # Check that the options are in the correct order
     configure_options_are_ok="$(CheckOptions $temporary_configure_options_file)"
-    
+
     # Kill the temporary file
     rm -f "$temporary_configure_options_file"
-    
+
     # Check if the options are okay
     if test "$configure_options_are_ok" != ""; then
 
@@ -390,11 +398,11 @@ if [[ "$new_configure_options" != "$old_configure_options" ||
         echo $configure_options_are_ok 1>&2
         echo  1>&2
         echo "===============================================================" 1>&2
-        
+
         # Failed
         exit 4
     fi
-        
+
     # Slight problem here: if we change the options and add a new
     # driver at the same time then configure will end up being re-run twice.
     # Don't think there's anything we can do about it
@@ -410,9 +418,9 @@ if [[ "$new_configure_options" != "$old_configure_options" ||
 
     # Finally run configure itself to convert "Makefile.in"s into "Makefile"s
     echo
-    echo "Running ./configure --prefix $build_dir $new_configure_options $extra_configure_options " 
+    echo "Running ./configure --prefix $build_dir $new_configure_options $extra_configure_options "
     echo
-    /bin/sh -c "./configure --prefix $build_dir $new_configure_options $extra_configure_options " 
+    /bin/sh -c "./configure --prefix $build_dir $new_configure_options $extra_configure_options "
 
     # Test that the mpi commands work with these configure options
     # (automatically passes if no variable MPI_RUN_COMMAND in makefile).
@@ -425,7 +433,7 @@ fi
 
 # If the temporary file still exists
 if [ -f "$temporary_configure_options_file" ]
-then  
+then
     # Kill it
     rm -f "$temporary_configure_options_file"
 fi
@@ -456,7 +464,7 @@ echo " "
 echo "Running make with make_options:"
 echo " "
 echo $make_options
-echo " " 
+echo " "
 
 make $make_options
 
@@ -468,7 +476,7 @@ echo " "
 echo "Running make install with make_options"
 echo " "
 echo $make_options
-echo " " 
+echo " "
 
 make $make_options install
 


### PR DESCRIPTION
## Description of change
<!-- Please provide a description of the change here. -->

Adds parallel support to the build and validation steps of the self-test workflows.

**Remark:** The level of parallelisation is somewhat limited as Linux virtual machines have 2 cores and macOS virtual machines have 3 cores (details here: [GitHub-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners)).

## Affected components
<!-- Please provide affected components. -->

- `.github/workflows/self-tests-ubuntu.yaml`: 
  - Now builds with 2 jobs and runs the self-tests using `bin/parallel_self_test.py`.

- `.github/workflows/self-tests-macos.yaml`: 
  - Now builds with 6 jobs and runs the self-tests using `bin/parallel_self_test.py`.

The number of jobs used for each OS was decided based on the results below.

## Links to self-test workflows
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

Given that Linux and macOS VMs only have 2 and 3 cores, respectively, I expected to max out the self-test speed with 2 jobs on Linux and 3 jobs on macOS. There was little variation in the timings when I used 2 jobs and 4 jobs on Ubuntu but, curiously, the workflow completed nearly 20% faster with 6 jobs than with 3 jobs on macOS. Results below:

- [Ubuntu (2 jobs):](https://github.com/PuneetMatharu/oomph-lib/actions/runs/1140091497): Time taken: 2h 2m.
- [Ubuntu (4 jobs):](https://github.com/PuneetMatharu/oomph-lib/actions/runs/1140091126) Time taken: 2h 4m.
- [macOS (3 jobs):](https://github.com/PuneetMatharu/oomph-lib/actions/runs/1140091500) Time taken: 1h 50m.
- [macOS (6 jobs):](https://github.com/PuneetMatharu/oomph-lib/actions/runs/1140091124) Time taken: 1h 31m.

## Dependencies

The PR builds on top of the patched changes in https://github.com/oomph-lib/oomph-lib/pull/27. To avoid the self-tests failing immediately, I recommend waiting until the PR linked is merged in before merging this one in. 

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] The Ubuntu tests pass.
- [ ] The macOS tests pass.
- [ ] PR dependencies have been merged in (i.e. https://github.com/oomph-lib/oomph-lib/pull/27).
