### PR TITLE
Tidy up the tutorials that broke because of clang-format

### DIFF
--- a/doc/interaction/fsi_collapsible_channel_adapt/fsi_collapsible_channel_adapt.txt
+++ b/doc/interaction/fsi_collapsible_channel_adapt/fsi_collapsible_channel_adapt.txt
@@ -350,13 +350,13 @@ vector of \c GeomObjects that are involved in this node's node-update
 with the pointer to the (sub-)\c GeomObject just located:
 
 \skipline Update the pointer to the (sub-)
-\until geom_object_pt[0]=
+\until geom_object_pt[0] =
 
 Similarly, we over-write the third reference value with the local
 coordinate of the reference point within its (sub-)\c GeomObject.
 
 \skipline Update third reference value
-\until ref_value[2]=
+\until ref_value[2] =
 
 The incorrect entries in the two vectors 
 \c geom_object_pt and \c ref_value have now been corrected. We can

--- a/doc/interaction/fsi_collapsible_channel_algebraic/fsi_chan_alg.txt
+++ b/doc/interaction/fsi_collapsible_channel_algebraic/fsi_chan_alg.txt
@@ -180,7 +180,7 @@ a separate function so it can be called from additional
 mesh constructors that are not discussed here.) The destructor
 remains empty.
 
-\until virtual ~AlgebraicCollapsibleChannelMesh(){}
+\until virtual ~AlgebraicCollapsibleChannelMesh()
 
 The function \c algebraic_node_update(...) is defined as a pure virtual
 function in the \c AlgebraicMesh base class and therefore must be 
@@ -214,7 +214,7 @@ non-FSI example</A> for details.)
 
 \dontinclude collapsible_channel_mesh.template.cc
 \skipline start_setup
-\until x<=(l_up+l_collapsible)  
+\until x <= (l_up + l_collapsible)  
 
 Assuming that the wall is in its undeformed position (we'll check
 this in a second...), we determine the intrinsic coordinate 
@@ -236,7 +236,7 @@ AlgebraicNode. The node update function involves a single \c
 GeomObject: The (sub-)\c GeomObject within which the reference
 point on the upper wall is located.
 
-\until geom_object_pt[0]=
+\until geom_object_pt[0] =
 
 As in the mesh used in the 
 <A HREF="../../../navier_stokes/algebraic_collapsible_channel/html/index.html">

--- a/doc/interaction/vmtk_fsi/vmtk_fsi.txt
+++ b/doc/interaction/vmtk_fsi/vmtk_fsi.txt
@@ -227,7 +227,7 @@ the element's private member data.
 \skipline Constructor takes a "bulk"
 \until FaceElement()
 \skipline {
-\until Id=
+\until Id =
 
 
 [We omit a few lines of code that are irrelevant for the

--- a/doc/linear_solvers/linear_solvers.txt
+++ b/doc/linear_solvers/linear_solvers.txt
@@ -35,7 +35,7 @@ LinearSolver</CODE></a> which contains a single pure virtual function
 
 
 \dontinclude linear_solver.h
-\skipline virtual void solve(Problem* const &problem_pt, DoubleVector &result)=0;
+\skipline virtual void solve(Problem* const& problem_pt, DoubleVector& result) = 0;
 
 whose task it is to compute the solution \f$ \delta {\bf x} \f$ (returned
 in the vector \c result) of the linear system

--- a/doc/multi_physics/multi_domain_ref_b_convect/multi_domain_ref_b_convect.txt
+++ b/doc/multi_physics/multi_domain_ref_b_convect/multi_domain_ref_b_convect.txt
@@ -352,7 +352,9 @@ element that determines the temperature distribution.
 
 We provide access functions to the Rayleigh number
 
-\until return Ra_pt;}
+\until }
+
+#return Ra_pt;}
 
 and, given that we are dealing with a refineable element, 
 make sure that the pointer to the Rayleigh number is passed to the
@@ -392,7 +394,7 @@ freedom, as implemented in
 
 \dontinclude multi_domain_boussinesq_elements.h
 \skipline Compute the element's residual vector and 
-\until fill_in_contribution_to_jacobian(residuals,jacobian);
+\until fill_in_contribution_to_jacobian(residuals, jacobian);
 
 and then fill in the derivatives with respect to 
 the degrees of freedom associated with the "external
@@ -442,7 +444,7 @@ the "external element":
 
 \dontinclude multi_domain_boussinesq_elements.h
 \skipline  Overload the wind
-\until }  //end of get_wind_adv_diff
+\until } // end of get_wind_adv_diff
 
 Again, there is only one external interaction so the interaction index
 is set to zero and the external element

--- a/doc/navier_stokes/spine_channel/spine_channel.txt
+++ b/doc/navier_stokes/spine_channel/spine_channel.txt
@@ -354,7 +354,7 @@ from \c RectangularQuadMesh<ELEMENT> and \c SpineMesh. The latter adds
 the functionality needed for using Spines.
 
 \dontinclude channel_spine_mesh.template.h
-\skipline template <
+\skipline template<
 \until public SpineMesh
 
 All SpineMeshs must include a function \c spine_node_update(SpineNode*
@@ -413,7 +413,7 @@ each region.
 
 Now we allocate storage for the parameters used to build the spines.
 
-\until n_prev_elements=0;
+\until n_prev_elements = 0;
 
 Now we create the first Spine with unit length, pin the height (since
 it is not a degree of freedom in this mesh) and push the spine back
@@ -429,7 +429,7 @@ part of this mesh.
 
 We then mark the node as part of the left (0) region.
 
-\until node_update_fct_id()=0;
+\until node_update_fct_id() = 0;
 
 When we built the Spine, we set its height to 1.0. We now need to
 assign its height from the \c Straight_wall_pt and assign all the


### PR DESCRIPTION
What it says... There are two tutorials that still break: Andrew's free surface tutorial and a tutorial associated with the recently deleted unstructured shell element driver code. Am consulting with Andrew what to do about this so both of these are in his court.