### PR TITLE
Update copyright notice script and apply to missed file

### DIFF
--- a/bin/update_copyright_licence_header.sh
+++ b/bin/update_copyright_licence_header.sh
@@ -13,19 +13,19 @@ set -e
 current_filename=$(basename "$0")
 
 # Search for all files containing the copyright notice
-oomph_lib_copyrighted_files=$(grep . -R -l --exclude="$current_filename" -e 'Copyright (C) 2006-' -e ' Matthias Heil and Andrew Hazel')
+oomph_lib_copyrighted_files=$(grep . -R -l --exclude="$current_filename" -e '[Cc]opyright ([Cc]) 2006-')
 
 # --------[ UPDATE COPYRIGHT YEAR ]---------------------------------------------
 
 # The end-year to update the notice to
 current_year=$(date +"%Y")
 
-# Update the licence header for each file. Don't use the "-i" flag for an
-# in-place edit as this flag is not supported by the BSD version of "sed" that
-# ships with macOS
+# Update the licence header for each file. Don't attempt an in-place edit using
+# the "-i" flag as it is not supported by the BSD version of "sed" that ships
+# with macOS
 for file in $oomph_lib_copyrighted_files; do
     echo "Updating copyright notice for file:" $file
-    sed "s/Copyright (C) 2006-.* Matthias Heil and Andrew Hazel/Copyright (C) 2006-$current_year Matthias Heil and Andrew Hazel/g" $file >$file.updated
+    sed "s/[Cc]opyright ([Cc]) 2006-20[0-9][0-9]/Copyright (C) 2006-$current_year/g" $file >$file.updated
     mv $file.updated $file
 done
 

--- a/doc/copyright/copyright.txt
+++ b/doc/copyright/copyright.txt
@@ -5,53 +5,53 @@
 freely downloaded and distributed -- the full details
 are given below. To facilitate the installation of the library,
 the \c oomph-lib distribution includes (parts of)
-certain other open source libraries (SuperLU, METIS and BLAS). 
+certain other open source libraries (SuperLU, METIS and BLAS).
 Redistribution of these libraries with \c oomph-lib has been
 approved by their authors -- we suggest you get in touch with
 them if you wish to re-distribute their libraries yet again.
 
 <HR>
 
-<H2><TT>oomph-lib's</TT> licencing terms</H2> 
+<H2><TT>oomph-lib's</TT> licencing terms</H2>
 
 This library is free software; you can redistribute it and/or
-modify it under the terms of the  
+modify it under the terms of the
 <a href="http://www.gnu.org/licenses/lgpl.html">
-GNU Lesser General Public License 
-</a> as published by the 
-<a href="http://www.fsf.org/">Free Software Foundation</a> ; 
+GNU Lesser General Public License
+</a> as published by the
+<a href="http://www.fsf.org/">Free Software Foundation</a> ;
 either version 2.1 of the License, or (at your option) any later version.
 This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
-See the 
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the
 <a href="http://www.gnu.org/licenses/lgpl.html">
-GNU Lesser General Public License 
+GNU Lesser General Public License
 </a>
 for more details.
 
 <br>
 <br>
 
-Your use or distribution of \c oomph-lib or any derivative code 
+Your use or distribution of \c oomph-lib or any derivative code
 implies that you  agree to this License.
 
 <br>
 <br>
-Copyright (c) 2006-2021 by 
-<a href="http://www.maths.man.ac.uk/~mheil">Matthias Heil</a> 
+Copyright (C) 2006-2021 by
+<a href="http://www.maths.man.ac.uk/~mheil">Matthias Heil</a>
 and <a href="http://www.maths.man.ac.uk/~ahazel">Andrew L. Hazel</a>.
 
 <HR>
 
 
-<H2>Licencing details for SuperLU</H2> 
+<H2>Licencing details for SuperLU</H2>
 The \c oomph-lib distribution includes the double precision versions
-of the sparse direct linear solver SuperLU (version 3.0 of the 
+of the sparse direct linear solver SuperLU (version 3.0 of the
 serial version and version 2.0 of the distributed memory parallel
-version). Full details of the 
-<A HREF="http://crd.lbl.gov/~xiaoye/SuperLU">SuperLU</A> 
-licence may be found at 
+version). Full details of the
+<A HREF="http://crd.lbl.gov/~xiaoye/SuperLU">SuperLU</A>
+licence may be found at
 <CENTER>
 <A HREF="http://crd.lbl.gov/~xiaoye/SuperLU">
 http://crd.lbl.gov/~xiaoye/SuperLU</A>
@@ -60,13 +60,13 @@ http://crd.lbl.gov/~xiaoye/SuperLU</A>
 
 <HR>
 
-<H2>Licencing details for METIS</H2> 
+<H2>Licencing details for METIS</H2>
 The \c oomph-lib distribution includes version 4.0 of
-George Karypis'  
+George Karypis'
 <A HREF="http://www-users.cs.umn.edu/~karypis/metis/">METIS</A>
-mesh partitioning library. Full details of the 
+mesh partitioning library. Full details of the
 <A HREF="http://www-users.cs.umn.edu/~karypis/metis/">METIS</A>
-licence may be found at 
+licence may be found at
 <CENTER>
 <A HREF="http://www-users.cs.umn.edu/~karypis/metis/">
 http://www-users.cs.umn.edu/~karypis/metis/
@@ -76,12 +76,12 @@ http://www-users.cs.umn.edu/~karypis/metis/
 
 <HR>
 
-<H2>Licencing details for BLAS/LAPACK</H2> 
+<H2>Licencing details for BLAS/LAPACK</H2>
 The \c oomph-lib distribution includes the entire BLAS library
 and a few functions from LAPACK.
-Full licencing details for the 
+Full licencing details for the
 <A HREF="http://www.netlib.org/blas/">BLAS library</A>
-may be found at 
+may be found at
 <CENTER>
 <A HREF="http://www.netlib.org/blas/">
 http://www.netlib.org/blas/
@@ -89,7 +89,7 @@ http://www.netlib.org/blas/
 </CENTER>
 Full licencing details for the
 <A HREF="http://www.netlib.org/lapack/">LIBRARY library</A>
-may be found at 
+may be found at
 <CENTER>
 <A HREF="http://www.netlib.org/lapack/">
 http://www.netlib.org/lapack/
@@ -101,15 +101,15 @@ http://www.netlib.org/lapack/
 
 <HR>
 
-<H2>Licencing details for GMP</H2> 
+<H2>Licencing details for GMP</H2>
 The \c oomph-lib distribution includes version 6.1.2 of
-the GNU Multiple Precision Arithmetic Library (GMP), 
+the GNU Multiple Precision Arithmetic Library (GMP),
   <a href="https://gmplib.org">https://gmplib.org</a>
 which is released under the
 <a href="https://www.gnu.org/licenses/lgpl.html">GNU LGPL v3</a>
 and <a href="https://www.gnu.org/licenses/gpl-2.0.html">GNU GPL
 v2</a> licences.
-Full details of the licence may be found at 
+Full details of the licence may be found at
 <CENTER>
 <a href="https://gmplib.org">https://gmplib.org</a>
 </CENTER>
@@ -119,29 +119,29 @@ Full details of the licence may be found at
 
 <HR>
 
-<H2>Licencing details for MPFR</H2> 
+<H2>Licencing details for MPFR</H2>
 The \c oomph-lib distribution includes version 3.1.6 of
 the GNU MPFR Library
   <a href="http://www.mpfr.org/">http://www.mpfr.org/</a>
-which is released under the 
+which is released under the
 <a href="http://www.gnu.org/copyleft/lesser.html">GNU
 Lesser General Public License</a> (GNU Lesser GPL).
 
-Full details of the licence may be found at 
+Full details of the licence may be found at
 <CENTER>
 <a href="http://www.mpfr.org/">http://www.mpfr.org/</a>
 </CENTER>
 
 <HR>
 
-<H2>Licencing details for Boost</H2> 
+<H2>Licencing details for Boost</H2>
 The \c oomph-lib distribution includes version 1.65.1 of
 the Boost Library
   <a href="http://www.boost.org/">http://www.boost.org/</a>
 which is released under the <a href="http://www.boost.org/LICENSE_1_0.txt">
 Boost Software Licence Version 1.0</a>.
 
-Full details of the licence may be found at 
+Full details of the licence may be found at
 <CENTER>
 <a href="http://www.boost.org/users/license.html">http://www.boost.org/users/license.html</a>
 </CENTER>
@@ -150,16 +150,16 @@ Full details of the licence may be found at
 
 <HR>
 
-<H2>Licencing details for CGAL</H2> 
+<H2>Licencing details for CGAL</H2>
 The \c oomph-lib distribution includes version 4.11 of
 CGAL The Computational Geometry Algorithms Library
   <a href="https://www.cgal.org/">https://www.cgal.org/</a>
 which is released under the distributed under a dual license scheme,
 that is under the <a href="https://www.gnu.org/copyleft/gpl.html">GPL</a>/
-<a href="https://www.gnu.org/copyleft/lesser.html">LGPL</a> 
+<a href="https://www.gnu.org/copyleft/lesser.html">LGPL</a>
 open source license, as well as under commercial licenses.
 
-Full details of the licence may be found at 
+Full details of the licence may be found at
 <CENTER>
 <a href="https://doc.cgal.org/latest/Manual/preliminaries.html#licenseIssues">https://doc.cgal.org/latest/Manual/preliminaries.html#licenseIssues</a>
 </CENTER>


### PR DESCRIPTION
## Description of change
<!-- Please provide a description of the change here. -->

Patches issue with copyright notice update script missing a file.

## Affected components
<!-- Please provide affected components. -->

- `bin/update_copyright_licence_header.sh`: 

  - Updated the `grep` and `sed` commands to only search (case-insensitively) for "Copyright (C) 2006-" (i.e. it doesn't search for the author names.