### PR TITLE
Tidy up of CONTRIBUTING.md as per Paul's suggestions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -399,9 +399,9 @@ To manually format specific files containing C++ code with `clang-format`, you
 will need to pass their names to the `clang-format` command and also specify the
 `-i` and `--style=file` flags. These flags specify that the formatting should be
 performed "in-place" and using the style specification provided in the
-`.clang-format` file (which should be located in one of the parent directories
-of the source file), respectively. For example, to format two files named
-`file1.cc` and `file2.cc`, use the following:
+`.clang-format` file (which should be located either in the current directory
+or in one of its parent directories -- the "nearest one" is used), respectively. 
+For example, to format two files named `file1.cc` and `file2.cc`, use the following:
 ```bash
 >>> clang-format -i --style=file file1.cc file2.cc
 ```


### PR DESCRIPTION
## Description of change
<!-- Please provide a description of the change here. -->

Tidies up the `CONTRIBUTING.md` guide as per Paul's comments (see https://github.com/oomph-lib/oomph-lib/issues/36).

## Affected components
<!-- Please provide affected components. -->

- `CONTRIBUTING.md`: 
  - Added information on how to run `clang-format` manually.
  - Removed the description of the upstream remote from "Basic setup".
  - Update a link to use Markdown-style links (not included in Paul's suggestions).
  - Added a note to the user that they should regularly do `git pull`.

## Remarks

- Might need to add a comment about how the user can rebase their feature branch after they've pulled in upstream changes.