### PR TITLE
Add redirection from GitHub docs URL to actual homepage

### DIFF
--- a/.github/workflows/build-and-publish-docs.yaml
+++ b/.github/workflows/build-and-publish-docs.yaml
@@ -27,6 +27,8 @@ jobs:
       run: make -C doc
     - name: Run website install script
       run: ./bin/website_install.sh
+    - name: Grab redirect file
+      run: cp ./bin/redirect.html ./build/website/index.html
     - name: Deploy
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:

--- a/bin/redirect.html
+++ b/bin/redirect.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting to documentation...</title>
+    <meta http-equiv="refresh" content="0; URL=./doc/html/" />
+    <link rel="canonical" href="./doc/html/" />
+  </head>
+
+  <body>
+    <p>Redirecting...</p>
+  </body>
+</html>


### PR DESCRIPTION
## Description of change

Fixes the issue with the direct link to the GitHub pages link not working.

## Affected components

- `redirect.html`: 
  - Helps redirect the user from the base `gh-pages` folder to the `doc/html/` folder to view the official homepage
  - Gets copied to the `build/website/` folder (for the `gh-pages` branch) under the name `index.html`.
- `.github/workflows/build-and-publish-docs.yaml`: 
  - Added an extra step to copy the `redirect.html` file to `build/website/index.html` which will become the root `index.html` file on the `gh-pages` branch.
