### PR TITLE
Fix auto-generated title in Doxygen documentation.

### DIFF
--- a/doc/doc.txt
+++ b/doc/doc.txt
@@ -1,4 +1,4 @@
-\mainpage
+\mainpage notitle
 \htmlonly
 
 <div id="carousel-example-generic" class="carousel slide" data-ride="carousel" >


### PR DESCRIPTION
Doxygen automatically generates the title "My Project Documentation" if you don't pass the `notitle` argument to the `\mainpage` command. I've now added the argument to fix the documentation. Details [here](https://www.doxygen.nl/manual/commands.html#cmdmainpage).

Addresses one of the tasks in issue https://github.com/oomph-lib/oomph-lib/issues/41.