### PR TITLE
Patch issue with 'delete'-d solve() function of ComplexDampedJacobi and parallel_self_test.py

### DIFF
--- a/demo_drivers/multigrid/helmholtz_multigrid/validate.sh
+++ b/demo_drivers/multigrid/helmholtz_multigrid/validate.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# Get the OOPMH-LIB root directory from a makefile
+# Get the OOMPH-LIB root directory from a makefile
 #-------------------------------------------------
 OOMPH_ROOT_DIR=$(make -s --no-print-directory print-top_builddir)
 
 # The base directory
 #-------------------
-base_dir=`pwd`;
+base_dir=$(pwd)
 
 # Set the number of tests to be checked (checking convergence AND trace file)
 #----------------------------------------------------------------------------
@@ -27,33 +27,24 @@ result_dir="RESLT"
 # Make the working directory
 #---------------------------
 # If the directory doesn't exist
-if [ -d $temp_dir ];
-then
+if [ -d $temp_dir ]; then
     rm -rf $temp_dir
 fi
 
 # Now make it
-mkdir $temp_dir;
+mkdir $temp_dir
 
 # Make the validata directory
 #----------------------------
 # If the directory doesn't exist
-if [ ! -d $store ];
-then
+if [ ! -d $store ]; then
     # If the directory doesn't exist, make it
     mkdir $store
 fi
 
 # Which code do you want to run?
 #-------------------------------
-code_stem=(unstructured_two_d_helmholtz structured_cubic_point_source);
-
-# Build the codes
-#----------------
-for code in ${code_stem[@]}
-do
-    make $code;
-done
+code_stem=(unstructured_two_d_helmholtz structured_cubic_point_source)
 
 # Jump in to the validation directory
 #------------------------------------
@@ -61,68 +52,66 @@ cd $temp_dir
 
 # Copy the executable into this directory
 #----------------------------------------
-for code in ${code_stem[@]}
-do
+for code in ${code_stem[@]}; do
     cp ../$code ./
 done
 
 # Set array of polynomial degrees to be used
 #-------------------------------------------
-nnode_1d=2;
+nnode_1d=2
 
 # Refinement levels
 #------------------
-add_refine=0;
-min_refine=1;
+add_refine=0
+min_refine=1
 
 # Linear solver
 #--------------
 # For the purposes of validation we only use the MG solver
-linear_solver=1;
+linear_solver=1
 
 # MG smoother
 #------------
-pre_smoother=1;
-post_smoother=1;
+pre_smoother=1
+post_smoother=1
 
-# Value of k^2 
+# Value of k^2
 #-------------
-k_sq=0.0;
+k_sq=0.0
 
 # Number of PML elements
 #-----------------------
-npml_element=1;
+npml_element=1
 
 # Use the test PML mapping?
 #--------------------------
-test_pml_mapping=1;
+test_pml_mapping=1
 
 # Alpha value
 #------------
-alpha=0.5;
+alpha=0.5
 
 # Ask for the convergence information
 #------------------------------------
-conv_flag=1;
+conv_flag=1
 
 # Set the output file name
 #-------------------------
-output_file=output_file.txt;
+output_file=output_file.txt
 
 # Delete it if it already exists
 #-------------------------------
-if [ -e $output_file ]
-then
+if [ -e $output_file ]; then
     rm -f $output_file
 fi
 
 # Create the output file
 #-----------------------
-touch $output_file	
+touch $output_file
 
 # Create the gzipped filename suffix
 #-----------------------------------
-gzip_suffix=".gz";
+gzip_suffix=".gz"
 
 # Create the file names:
 #-----------------------
@@ -134,7 +123,7 @@ trace_file="/trace.dat"
 
 # Threshold for number of iterations in comparison of convergence histories:
 #---------------------------------------------------------------------------
-threshold_n_its=3;
+threshold_n_its=3
 
 # The address of the bash script to compare file lengths
 #-------------------------------------------------------
@@ -146,42 +135,37 @@ compare_data="../../../../bin/fpdiff.py"
 
 # Run the program with the specified properties
 #----------------------------------------------
-for code in ${code_stem[@]}
-do
-    if [ $code == ${code_stem[0]} ]
-    then
-	echo "Running multigrid validation with 2D Helmholtz problem"
+for code in ${code_stem[@]}; do
+    if [ $code == ${code_stem[0]} ]; then
+        echo "Running multigrid validation with 2D Helmholtz problem"
     else
-	echo "Running multigrid validation with 3D Helmholtz problem"
+        echo "Running multigrid validation with 3D Helmholtz problem"
     fi
-    
+
     # Make it
     #--------
-    if [ ! -d $result_dir ];
-    then
-	mkdir $result_dir;
+    if [ ! -d $result_dir ]; then
+        mkdir $result_dir
     fi
-    
+
     # If we're working in 2D we can deal with a higher value of k^2
     # but it takes much longer in 3D so use a lower wavenumber in 3D
     #---------------------------------------------------------------
-    if [ $code == ${code_stem[0]} ]
-    then
-	k_sq=30.0;
+    if [ $code == ${code_stem[0]} ]; then
+        k_sq=30.0
     else
-	k_sq=15.0;
+        k_sq=15.0
     fi
-    
+
     # If we're working in 2D use quadratic elements otherwise use linear
     # elements since the cost of quadratic elements in 3D is extremely large
     #-----------------------------------------------------------------------
-    if [ $code == ${code_stem[0]} ]
-    then
-	nnode_1d=3;
+    if [ $code == ${code_stem[0]} ]; then
+        nnode_1d=3
     else
-	nnode_1d=2;
+        nnode_1d=2
     fi
-    
+
     # Set the inputs
     #---------------
     command_line_flag="--add_ref $add_refine "
@@ -197,105 +181,98 @@ do
 
     # Extra inputs which are only relevant to one specific code
     #----------------------------------------------------------
-    if [ $code == ${code_stem[0]} ]
-    then
-	# Can only set the number of PML layers in the 3D case
-	command_line_flag+="--npml_element $npml_element "
+    if [ $code == ${code_stem[0]} ]; then
+        # Can only set the number of PML layers in the 3D case
+        command_line_flag+="--npml_element $npml_element "
     fi
 
     # Run the code and direct the output into the output file
     #--------------------------------------------------------
-    ./$code $command_line_flag >> $output_file
-    
+    ./$code $command_line_flag >>$output_file
+
     # Create a little pause on the 3D problem
     #----------------------------------------
-    if (( ${#code_stem[@]} > 1 ))
-    then		    
-	if [ $code == ${code_stem[1]} ]
-	then
-	    sleep 3s
-	fi
+    if ((${#code_stem[@]} > 1)); then
+        if [ $code == ${code_stem[1]} ]; then
+            sleep 3s
+        fi
     fi
 
     # Create some output in the validation.log file:
     #-----------------------------------------------
-    echo " " >> validation.log
-    echo "-------------------------------------------------------------" >> validation.log
-    if [ $code == ${code_stem[0]} ]
-    then
-	echo "Complex-valued multigrid validation with 2D Helmholtz problem" >> validation.log
+    echo " " >>validation.log
+    echo "-------------------------------------------------------------" >>validation.log
+    if [ $code == ${code_stem[0]} ]; then
+        echo "Complex-valued multigrid validation with 2D Helmholtz problem" >>validation.log
     else
-	echo "Complex-valued multigrid validation with 3D Helmholtz problem" >> validation.log
+        echo "Complex-valued multigrid validation with 3D Helmholtz problem" >>validation.log
     fi
-    echo "-------------------------------------------------------------" >> validation.log
-    echo "Problem properties:" >> validation.log
+    echo "-------------------------------------------------------------" >>validation.log
+    echo "Problem properties:" >>validation.log
 
     # Interpolation scheme:
     #----------------------
     string="Interpolation scheme:"
-    if [ $nnode_1d == 2 ]
-    then
-	echo "$string Linear" >> validation.log
-    elif [ $nnode_1d == 3 ]
-    then
-	echo "$string Quadratic" >> validation.log
+    if [ $nnode_1d == 2 ]; then
+        echo "$string Linear" >>validation.log
+    elif [ $nnode_1d == 3 ]; then
+        echo "$string Quadratic" >>validation.log
     else
-	echo "$string Cubic" >> validation.log		
+        echo "$string Cubic" >>validation.log
     fi
 
     # Value of the square of the wavenumber:
     #---------------------------------------
-    echo "Value of k^2: $k_sq" >> validation.log
-    
+    echo "Value of k^2: $k_sq" >>validation.log
+
     # Value of the shift:
     #--------------------
-    echo "Value of alpha: $alpha" >> validation.log
-    
+    echo "Value of alpha: $alpha" >>validation.log
+
     # Refinement scheme:
     #-------------------
-    echo "Refinement scheme: Uniform refinement" >> validation.log
-    echo "--------------------------------------" >> validation.log
-    echo " " >> validation.log
-    echo "Validation directory: " >> validation.log
-    echo " " >> validation.log
-    echo "  " `pwd` >> validation.log
-    echo " " >> validation.log
+    echo "Refinement scheme: Uniform refinement" >>validation.log
+    echo "--------------------------------------" >>validation.log
+    echo " " >>validation.log
+    echo "Validation directory: " >>validation.log
+    echo " " >>validation.log
+    echo "  " $(pwd) >>validation.log
+    echo " " >>validation.log
 
     # Create the unique output file using the identifying parameters
     #---------------------------------------------------------------
-    filename="/$code";
-    filename+="_ksq_"$k_sq;
-    filename+="_alpha_"$alpha;
-    
+    filename="/$code"
+    filename+="_ksq_"$k_sq
+    filename+="_alpha_"$alpha
+
     # We need a unique filename for the convergence history
     #------------------------------------------------------
     conv_filename=$filename"_conv.dat"
     trace_filename=$filename"_trace.dat.gz"
-    
+
     # Check trace.dat and conv.dat
     #-----------------------------
-    if test "$1" = "no_fpdiff";
-    then
-	echo "dummy [OK] -- Can't run fpdiff.py because we don't have python or validata" >> validation.log
+    if test "$1" = "no_fpdiff"; then
+        echo "dummy [OK] -- Can't run fpdiff.py because we don't have python or validata" >>validation.log
     else
-	./$compare_data ../$store$trace_filename $result_dir$trace_file >> validation.log
-	
-	# Compare number of iterations against reference data and append
-	./$compare_length $result_dir$conv_file ../$store$conv_filename $threshold_n_its >> validation.log
+        ./$compare_data ../$store$trace_filename $result_dir$trace_file >>validation.log
+
+        # Compare number of iterations against reference data and append
+        ./$compare_length $result_dir$conv_file ../$store$conv_filename $threshold_n_its >>validation.log
     fi
 
     # Move the result directory into storage
     #---------------------------------------
     new_result_dir=$result_dir"_"$code
     mv $result_dir $new_result_dir
-    
+
     # Notify the user that we've finished the test
     echo "done"
 done
 
 # Append output to global validation log file
 #--------------------------------------------
-cat validation.log >> ../../../../validation.log
+cat validation.log >>../../../../validation.log
 
 # Now jump back to the base directory
 #------------------------------------

--- a/src/pml_helmholtz/complex_smoother.h
+++ b/src/pml_helmholtz/complex_smoother.h
@@ -483,7 +483,10 @@ namespace oomph
     /// This obtains the Jacobian matrix J and the residual vector r
     /// (needed for the Newton method) from the problem's get_jacobian
     /// function and returns the result of Jx=r.
-    void solve(Problem* const& problem_pt, DoubleVector& result) = delete;
+    void solve(Problem* const& problem_pt, DoubleVector& result)
+    {
+      BrokenCopy::broken_assign("ComplexDampedJacobi");
+    }
 
     /// Number of iterations taken
     unsigned iterations() const


### PR DESCRIPTION
## Description

Accidentally `delete`-d the broken virtual `solve()` function in `ComplexDampedJacobi` (that obviously shouldn't have been made to use `delete`). Credit to @PaulAlexander23 for spotting this mistake (thanks!) (see https://github.com/oomph-lib/oomph-lib/pull/48#discussion_r710429110). The self-tests didn't _appear_ to fail so I thought everything was fine. It turns out that some self-tests failed but the self-test workflow didn't recognize the error. It could be that the `parallel_self_test.py` script doesn't provide an exit code when some self-tests fail to build. Need to sort this out; will add it onto my to-do list.

**Example self-test workflow showing false-positive:** [latest macOS self-test workflow](https://github.com/oomph-lib/oomph-lib/runs/3600730006?check_suite_focus=true); see the number of `BUILD FAIL`s in the `Validate` step.

## To-do list

- [x] Fix issue with parallel self-test not recognising failing self-tests.
- [x] Wait for the self-tests to pass.
  - [macOS self-tests (passed)](https://github.com/oomph-lib/oomph-lib/runs/3600730006?check_suite_focus=true)
  - [Ubuntu self-tests (passed)](https://github.com/oomph-lib/oomph-lib/runs/3600730019?check_suite_focus=true)