### PR TITLE
Move to C++11: Add support for construction of Vectors using initialiser_lists

### DIFF
--- a/src/generic/Vector.h
+++ b/src/generic/Vector.h
@@ -150,6 +150,13 @@ namespace oomph
     {
     }
 
+    /// \short A constructor that creates a vector with entries set by the
+    /// values in the input initialiser_list
+    /// Example:
+    ///           Vector<int> arr{0, 20, 100, 150);
+    ///           Vector<int> arr = {0, 20, 100, 150);
+    Vector(std::initializer_list<_Tp> init) : std::vector<_Tp>(init) {}
+
     /// Copy constructor
     Vector(const Vector<_Tp>& __x) : std::vector<_Tp>(__x) {}
 
@@ -231,6 +238,13 @@ namespace oomph
     Vector(size_type __n, const bool& __value) : std::vector<bool>(__n, __value)
     {
     }
+
+    /// \short A constructor that creates a vector with entries set by the
+    /// values in the input initialiser_list.
+    /// Example:
+    ///           Vector<int> arr{true, false, false, true);
+    ///           Vector<int> arr = {true, false, false, true);
+    Vector(std::initializer_list<bool> init) : std::vector<bool>(init) {}
 
     /// Copy constructor
     Vector(const Vector<bool>& __x) : std::vector<bool>(__x) {}


### PR DESCRIPTION
## Description

Adds some syntactic sugar for the construction of `Vector` objects. Makes use of `initialiser_list`s (not to be confused with constructor initialiser list), which are a C++11 construct.

## Example

### Original C++ code

Stolen from PR https://github.com/oomph-lib/oomph-lib/pull/48.

```cpp
Vector<std::complex<double>> values(4);
values[0] = std::complex<double>(1, 1);
values[1] = std::complex<double>(2, 1);
values[2] = std::complex<double>(3, 1);
values[3] = std::complex<double>(4, 1);

Vector<int> row_index(4);
row_index[0] = 0;
row_index[1] = 2;
row_index[2] = 1;
row_index[3] = 3;

Vector<int> column_start(3);
column_start[0] = 0;
column_start[1] = 2;
column_start[2] = 4;

Vector<std::complex<double>> values_square(7);
values_square[0] = std::complex<double>(1, 1);
values_square[1] = std::complex<double>(2, -1);
values_square[2] = std::complex<double>(3, 0.1);
values_square[3] = std::complex<double>(4, 3);
values_square[4] = std::complex<double>(5, 1);
values_square[5] = std::complex<double>(6, -2);
values_square[6] = std::complex<double>(0.5, -1);

Vector<int> row_index_square(7);
row_index_square[0] = 0;
row_index_square[1] = 2;
row_index_square[2] = 0;
row_index_square[3] = 1;
row_index_square[4] = 1;
row_index_square[5] = 2;
row_index_square[6] = 3;

Vector<int> column_start_square(5);
column_start_square[0] = 0;
column_start_square[1] = 2;
column_start_square[2] = 4;
column_start_square[3] = 6;
column_start_square[4] = 7;

Vector<std::complex<double>> x(4);
x[0] = std::complex<double>(2, 2);
x[1] = std::complex<double>(-2, 3);
x[2] = std::complex<double>(1, -2);
x[3] = std::complex<double>(-2, 1);

Vector<std::complex<double>> rhs(4);
rhs[0] = std::complex<double>(1, -0.5);
rhs[1] = std::complex<double>(0.5, 1.2);
rhs[2] = std::complex<double>(2, 0.3);
rhs[3] = std::complex<double>(-3, -0.4);
```

### Code using new constructor

```cpp
Vector<int> row_index{0, 2, 1, 3};
Vector<int> column_start{0, 2, 4};
Vector<std::complex<double>> values{{1, 1}, {2, 1}, {3, 1}, {4, 1}};

Vector<int> row_index_square{0, 2, 0, 1, 1, 2, 3};
Vector<int> column_start_square{0, 2, 4, 6, 7};
Vector<std::complex<double>> values_square{{1, 1}, {2, -1}, {3, 0.1}, {4, 3},
                                      {5, 1}, {6, -2}, {0.5, -1}};
                                      
Vector<std::complex<double>> x{{2, 2}, {-2, 3}, {1, -2}, {-2, 1}};
Vector<std::complex<double>> rhs{{1, -0.5}, {0.5, 1.2}, {2, 0.3}, {-3, -0.4}};
```

## Notes

- `initialiser_list` constructors are already available via direct access to other STL containers, e.g.

  ```cpp
  std::map<int, std::complex<double>>{
      {-3, {59.0, -1.0}},
      {20, {12.0, 5.0}},
      {5, {100.0, -9.0}},
      {299, {-1.0, 73.0}},
  };
  ```
  In this case, I just need to expose the underlying constructor in `std::vector` to the `Vector` wrapper class.
- You could also use this method to construct small dense matrices (i.e. as an `initialiser_list` of `initialiser_list`s), but I'm too lazy to do that myself.

## Self-tests

Still pass like normal:
- [![macOS self-tests](https://github.com/puneetmatharu/oomph-lib/actions/workflows/self-tests-macos.yaml/badge.svg?branch=feature-add-cxx11-vector-initialiser-constructor)](https://github.com/puneetmatharu/oomph-lib/actions/workflows/self-tests-macos.yaml?query=branch%3Afeature-add-cxx11-vector-initialiser-constructor)**
- [![Ubuntu self-tests](https://github.com/puneetmatharu/oomph-lib/actions/workflows/self-tests-ubuntu.yaml/badge.svg?branch=feature-add-cxx11-vector-initialiser-constructor)](https://github.com/puneetmatharu/oomph-lib/actions/workflows/self-tests-ubuntu.yaml?query=branch%3Afeature-add-cxx11-vector-initialiser-constructor)**

_**click the badge to check that the most recent test has finished and passed._