### PR TITLE
Patch hypre; remove some check for headers; clarify doc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -161,12 +161,13 @@ accumulated_cpp_flags=''
 # anything under GNU< Linux (MH 12/01/2007)
 #
 AC_HEADER_STDC
-AC_CHECK_HEADERS([limits.h stdlib.h string.h sys/time.h],
-                  [echo "Congratulations -- required headers were found";],
-                  [echo "==================================================";
-                   echo "Trouble -- missing header[s]! ";
-                   echo "==================================================";
-                   exit])
+
+#AC_CHECK_HEADERS([limits.h stdlib.h string.h sys/time.h],
+#                  [echo "Congratulations -- required headers were found";],
+#                  [echo "==================================================";
+#                   echo "Trouble -- missing header[s]! ";
+#                   echo "==================================================";
+#                   exit])
 
 
 #Check for the execinfo header

--- a/doc/coding_conventions/coding_conventions.txt
+++ b/doc/coding_conventions/coding_conventions.txt
@@ -116,7 +116,11 @@ too much.
    /// Total number of elements
    unsigned nelement();
    \endcode
- \b Notes: (i) No underscore between the "n" and the container's name.
+ \b Notes: (i) No underscore between the "n" and the container's name;
+ You can then use the underscore for the name of the local variable
+ that stores the value, e.g.
+ \c
+ unsigned \c n_element \c = \c my_mesh_pt->nelement();
 (ii) No trailing \c _pt in the function that returns the number
 of objects in the container.
 

--- a/doc/coding_conventions/coding_conventions.txt
+++ b/doc/coding_conventions/coding_conventions.txt
@@ -117,7 +117,7 @@ too much.
    unsigned nelement();
    \endcode
  \b Notes: (i) No underscore between the "n" and the container's name;
- You can then use the underscore for the name of the local variable
+ you can then use the underscore for the name of the local variable
  that stores the value, e.g.
  \c
  unsigned \c n_element \c = \c my_mesh_pt->nelement();

--- a/external_distributions/hypre/build_scripts/build_script.part1
+++ b/external_distributions/hypre/build_scripts/build_script.part1
@@ -50,4 +50,8 @@ tar xfz hypre-2.0.0.tar.gz
 # Go to it source directory
 cd  hypre-2.0.0/src
 
+# Patch for latest version of openmpi
+find . -type f -exec sed -i 's|MPI_Address|MPI_Get_address|g' {} \;
+find . -type f -exec sed -i 's|MPI_Type_struct|MPI_Type_create_struct|g' {} \;
+
 # Configure it


### PR DESCRIPTION
- Omitted some checks for headers in configure.ac since the test fails even though the headers are there. The problem appears to be that the headers can't be compiled independently -- don't quite understand the problem, and gave up trying to understand the logic...
- Patched hypre in the build script to make sure it works with the latest version of openmpi (original code uses deprecated mpi interfaces). Note that this isn't actually checked in the current github self-tests but the full mpi-based self-tests pass on my office machine which I've updated to ubuntu 20.04. Am in the process of writing an "Action" that does the self-tests for mpi too.
-  Clarified naming rules for variables and access functions related to the number of entries in a container (in coding conventions)