### PR TITLE
Patch uploading of validation.log (from workflow scripts) when self-tests fail

### DIFF
--- a/.github/workflows/self-tests-macos.yaml
+++ b/.github/workflows/self-tests-macos.yaml
@@ -22,8 +22,11 @@ jobs:
       - name: Build
         run: ./non_interactive_autogen.sh -s -j$(sysctl -n hw.logicalcpu)
 
+      # Continue running even if the test fails so that the validation.log can be
+      # uploaded and reviewed later on
       - name: Validate
         run: ./bin/parallel_self_test.py
+        continue-on-error: true
 
       - name: Upload validation log file
         uses: actions/upload-artifact@v2

--- a/.github/workflows/self-tests-ubuntu.yaml
+++ b/.github/workflows/self-tests-ubuntu.yaml
@@ -14,8 +14,11 @@ jobs:
     - name: Build
       run: ./non_interactive_autogen.sh -s -j$(nproc)
 
+    # Continue running even if the test fails so that the validation.log can be
+    # uploaded and reviewed later on
     - name: Validate
       run: ./bin/parallel_self_test.py
+      continue-on-error: true
 
     - name: Upload validation log file
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Description

Sorts out the issue with the `validation.log` not being uploaded when the self-tests fail; a minor issue that must have crept in when I updated the self-tests to run using `parallel_self_test.py`.