### PR TITLE
Patch self-tests workflows; propagate a non-zero exit code if the self-tests fail

### DIFF
--- a/.github/workflows/self-tests-macos.yaml
+++ b/.github/workflows/self-tests-macos.yaml
@@ -25,6 +25,7 @@ jobs:
       # Continue running even if the test fails so that the validation.log can be
       # uploaded and reviewed later on
       - name: Validate
+        id: self_tests
         run: ./bin/parallel_self_test.py
         continue-on-error: true
 
@@ -33,3 +34,7 @@ jobs:
         with:
           name: macos-latest validation log
           path: ./validation.log
+
+      - name: Propagate self-test status
+        if: steps.self_tests.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/self-tests-ubuntu.yaml
+++ b/.github/workflows/self-tests-ubuntu.yaml
@@ -6,22 +6,27 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Install requirements
-      run: sudo apt-get install make automake libtool libtool-bin autoconf doxygen gfortran g++
+      - name: Install requirements
+        run: sudo apt-get install make automake libtool libtool-bin autoconf doxygen gfortran g++
 
-    - name: Build
-      run: ./non_interactive_autogen.sh -s -j$(nproc)
+      - name: Build
+        run: ./non_interactive_autogen.sh -s -j$(nproc)
 
-    # Continue running even if the test fails so that the validation.log can be
-    # uploaded and reviewed later on
-    - name: Validate
-      run: ./bin/parallel_self_test.py
-      continue-on-error: true
+      # Continue running even if the test fails so that the validation.log can be
+      # uploaded and reviewed later on
+      - name: Validate
+        id: self_tests
+        run: ./bin/parallel_self_test.py
+        continue-on-error: true
 
-    - name: Upload validation log file
-      uses: actions/upload-artifact@v2
-      with:
-        name: ubuntu-latest validation log
-        path: ./validation.log
+      - name: Upload validation log file
+        uses: actions/upload-artifact@v2
+        with:
+          name: ubuntu-latest validation log
+          path: ./validation.log
+
+      - name: Propagate self-test status
+        if: steps.self_tests.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
## Description

Patches the issue where, if the self-tests fail, they're caught by the `continue-on-error` key but then the overall test is (misclassified) as a pass.

Also adds consistent indentation of steps between self-test workflows.