### PR TITLE
Add MPI testing for Ubuntu to self-test workflows

### DIFF
--- a/.github/workflows/self-tests-macos.yaml
+++ b/.github/workflows/self-tests-macos.yaml
@@ -10,9 +10,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install requirements
-        run: |
-          brew install make automake libtool autoconf doxygen
-          brew reinstall gfortran
+        run: brew install make automake libtool autoconf doxygen && brew reinstall gfortran
 
       - name: Extra config
         run:
@@ -32,7 +30,7 @@ jobs:
       - name: Upload validation log file
         uses: actions/upload-artifact@v2
         with:
-          name: macos-latest validation log
+          name: validation-${{ runner.os }}.log
           path: ./validation.log
 
       - name: Propagate self-test status

--- a/.github/workflows/self-tests-ubuntu.yaml
+++ b/.github/workflows/self-tests-ubuntu.yaml
@@ -4,15 +4,33 @@ on: push
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each map in the 'mpi_options' array contains a flag indicating whether
+        # to enable MPI and the name of the configuration file required for the
+        # MPI case, respectively
+        mpi_options: [
+          {enable: false, config_file: default},
+          {enable: true,  config_file: mpi_default_ci}
+        ]
+
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out repository
+        uses: actions/checkout@v2
 
       - name: Install requirements
         run: sudo apt-get install make automake libtool libtool-bin autoconf doxygen gfortran g++
 
+      - name: Install MPI requirements (if required)
+        if: ${{ matrix.mpi_options.enable == true }}
+        run: sudo apt-get install openmpi-bin libopenmpi-dev
+
       - name: Build
-        run: ./non_interactive_autogen.sh -s -j$(nproc)
+        run: |
+          config_file=config/configure_options/${{ matrix.mpi_options.config_file }};
+          ./non_interactive_autogen.sh -s -j$(nproc) -c $config_file
 
       # Continue running even if the test fails so that the validation.log can be
       # uploaded and reviewed later on
@@ -24,7 +42,7 @@ jobs:
       - name: Upload validation log file
         uses: actions/upload-artifact@v2
         with:
-          name: ubuntu-latest validation log
+          name: validation-${{ runner.os }}-MPI_${{ matrix.mpi_options.enable }}.log
           path: ./validation.log
 
       - name: Propagate self-test status

--- a/config/configure_options/mpi_default_ci
+++ b/config/configure_options/mpi_default_ci
@@ -1,0 +1,103 @@
+#=====================================================================
+# File that specifies options and compile/link flags for
+# autogen.sh script: Needs to be processed with autogen-setup.sh
+# and creates the shell script autogen-configure.sh that is executed
+# by autogen.sh.
+#
+#  NOTE: Options need to go first!
+#
+# A few options:    [type ./configure --help to see the full list]
+# --------------
+#
+#         --enable-MPI   includes all MPI sources into the build
+#                        (you will probably have to specify
+#                        your MPI libraries and include directories
+#                        in the compiler/linker options; see the
+#                        examples enclosed below).
+#         --enable-suppress-doc  Don't build the documentation (can take a long
+#                        and uses quite a bit of diskspace. You might
+#                        prefer to consult the online documentation at
+#                        http://www.oomph-lib.org
+#         --enable-suppress-demo Don't build the demo codes/self test
+#
+# Common compiler/linker flags:
+# -----------------------------
+#
+# - CXX =  C++ compiler (defaults to gcc/g++ if not specified)
+# - CC  =  C compiler (defaults to gcc if not specified)
+# - F77 =  F77 compiler (defaults to gcc/g77 if not specified)
+#
+# - CXXFLAGS = flags for the C++ compiler. Specify optmisation flags
+#              for your compiler (e.g. -O3 for maximum optimisation
+#              with the gcc compiler suite, enable debugging (-g for
+#              the gcc compilers), etc.)
+#
+#              Here's a list of useful oomph-lib related flags:
+#
+#              -DPARANOID enables "general paranoia", allowing the
+#                         code to perform various sanity checks
+#                         during execution. Incurs a moderate run-time
+#                         overhead.
+#              -DRANGE_CHECKING switches on bounds checking in
+#                         oomph-lib's Vector class (a wrapper to the
+#                         the STL vector class). This is VERY costly
+#                         in terms of run time but very useful for
+#                         tracking down the source of otherwise
+#                         inexcplicable segmentation faults...
+#              -DLEAK_CHECK mainly used during code developement. Used
+#                         to allow optional checks that objects are
+#                         deleted to avoid memory leaks.
+#              -DWARN_ABOUT_SUBTLY_CHANGED_OOMPH_INTERFACES throws
+#                         an oomph-lib warning whenever a function
+#                         whose interface has been changed "subtly"
+#                         (i.e. in a way that the compiler can't detect,
+#                         e.g. a change in the order of two arguments
+#                         of the same type) during some revision is called.
+#                         Use this only (!) if your code behaves
+#                         oddly after upgrading to a newer release
+#                         of the library.
+#
+# - CFLAGS   = flags for the C compiler. Specify optimisation flags
+#              for your compiler (e.g. -O3 for maximum optimisation
+#              with the gcc compiler suite, enable debugging (-g for
+#              the gcc compilers), etc.) The C-compiler is only used
+#              to compile certain external libraries, such as superlu.
+#              Therefore it is not necessary to specify any of
+#              oomph-lib's own compilation flags.
+#
+# - FFLAGS   = flags for the f77 compiler. Specify optimisation flags
+#              for your compiler (e.g. -O3 for maximum optimisation
+#              with the gcc compiler suite, enable debugging (-g for
+#              the gcc compilers), etc.) The f77-compiler is only used
+#              to compile certain external libraries, such as the
+#              frontal solver from the hsl library.
+#              Therefore it is not necessary to specify any of
+#              oomph-lib's own compilation flags.
+#
+# - FFLAGS_NO_OPT   = flags for the f77 compiler without optimisation,
+#              required for a couple of files in the BLAS library.
+#              Usually the flag is -O0, but you may wish/need to pass other
+#              flags as well. Unfortunately, there is no easy way to do this
+#              automatically so you have to do it yourself, sorry. In almost
+#              all cases you can copy FFLAGS and replace -O3 with -O0.
+#
+# - LIBS     = Specify any additional libraries that you might have
+#              to link against -- typically only required if  mpi is
+#              used. autoconf should automatically detect any
+#              other libraries.
+#=====================================================================
+--enable-suppress-doc
+--enable-symbolic-links-for-headers
+--enable-MPI
+--with-mpi-self-tests="mpirun -np 2"
+# Allow oversubscription of jobs to cores when running the CI tests (as the
+# number of cores provided by GitHub is limited)
+--with-mpi-self-tests-variablenp="mpirun -np OOMPHNP --oversubscribe"
+CXXFLAGS="-O3 -Wall"
+CFLAGS="-O3 -Wall"
+FFLAGS="-O3 -Wall"
+FFLAGS_NO_OPT="-O0"
+CXX=mpic++
+CC=mpicc
+F77=mpif77
+LD=mpif77


### PR DESCRIPTION
## Description

Adds support for testing MPI-enabled demo drivers on Ubuntu via the GitHub Action self-tests.

## Notes

- Added a very minor tweak to the macOS self-test workflow to tidy it up a little.
- Updated the names of the uploaded `validation.log` artefacts. For the Ubuntu self-test workflow, this will ensure that the log files don't overwrite each other when uploaded.
- The non-MPI-enabled job and the MPI-enabled job are combined into a single workflow using a `matrix`.
- The PR does **not** add an extra status badge to the `README.md` to display the status of MPI-enabled tests on Ubuntu because status badges are provided "per workflow/branch" rather than "per workflow job".
- Does not provide support for testing MPI-enabled demo drivers on macOS due to mysterious MPI-related seg. faults in the following demo drivers:
  1. `demo_drivers/mpi/distribution/adaptive_driven_cavity`
  1. `demo_drivers/mpi/distribution/bifurcation_tracking`
  1. `demo_drivers/mpi/distribution/hp_adaptive_driven_cavity`
  1. `demo_drivers/mpi/distribution/three_d_entry_flow`
  1. `demo_drivers/mpi/multi_domain/boussinesq_convection`
  1. `demo_drivers/mpi/multi_domain/turek_flag`

Four of these six failing drivers (ii, iv, v, vi) appear to die somewhere in `superlu_dist_distributed_matrix`. The other two (i and iii) die somewhere in the adaptive Newton solve.

You can find the [failing macOS self-tests output here](https://github.com/puneetmatharu/oomph-lib/actions/runs/1298069117). I've also attached the corresponding log-file here: [`validation-macOS-MPI_true.log`](https://github.com/oomph-lib/oomph-lib/files/7271668/validation-macOS-MPI_true.log).

## Self-tests

Below are the status badges for Ubuntu with and without MPI, and macOS with no MPI.

- [![Ubuntu self-tests](https://github.com/puneetmatharu/oomph-lib/actions/workflows/self-tests-ubuntu.yaml/badge.svg?branch=feature-add-mpi-testing-to-self-test-workflows)](https://github.com/puneetmatharu/oomph-lib/actions/workflows/self-tests-ubuntu.yaml?query=branch%3Afeature-add-mpi-testing-to-self-test-workflows)*
- [![macOS self-tests](https://github.com/puneetmatharu/oomph-lib/actions/workflows/self-tests-macos.yaml/badge.svg?branch=feature-add-mpi-testing-to-self-test-workflows)](https://github.com/puneetmatharu/oomph-lib/actions/workflows/self-tests-macos.yaml?query=branch%3Afeature-add-mpi-testing-to-self-test-workflows)*

*_Once these status badges become green, both tests have passed. You can also just click on them to see the test progress._