### PR TITLE
Add manual trigger for build and publish docs

### DIFF
--- a/.github/workflows/build-and-publish-docs.yaml
+++ b/.github/workflows/build-and-publish-docs.yaml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      publishBranch:
+        description: 'Branch to publish built docs'
+        required: true
+        default: 'gh-pages'
 
 jobs:
   build-and-deploy:
@@ -33,6 +39,6 @@ jobs:
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages # The branch the action should deploy to.
+        BRANCH: ${{ github.event.inputs.publishBranch }} # The branch the action should deploy to.
         FOLDER: build/website # The folder the action should deploy.
         CLEAN: true


### PR DESCRIPTION
Adding this would allow contributors to test the build of their docs without making changes on their main branch. See the github docs for how this works https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/