### PR TITLE
Update urls for new location of external distribution files

### DIFF
--- a/bin/change_urls.bash
+++ b/bin/change_urls.bash
@@ -1,0 +1,40 @@
+#! /bin/bash
+
+#-----------------------------------------------------------
+# Search through all files and replace one url with another
+# Ft. Puneet magic to escape awkward characters...
+#-----------------------------------------------------------
+
+orig_url=http://oomph-lib.maths.man.ac.uk/oomph-lib_external_distfiles
+orig_url=http://www.maths.manchester.ac.uk/~oomphlib/oomph-lib_external_distfiles
+
+new_url=https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles
+
+
+# Helper function to handle the typically-messy escaping of characters
+# Puneet's magic!
+escape_sed_args() {
+    echo "$1" | sed 's/[\/&]/\\&/g'
+}
+
+# Escape characters
+orig_url=$(escape_sed_args "$orig_url")
+new_url=$(escape_sed_args "$new_url")
+
+sed_string="s/"$orig_url"/"$new_url"/g"
+echo $sed_string
+
+
+
+echo "find . \( ! -name .command.bash -a ! -name change_urls.bash \) -type f -exec grep -m 1 -H '"$orig_url"' {} \;" > .command.bash
+chmod a+x .command.bash
+full_list=`./.command.bash`
+rm -f .command.bash
+
+for full_line in `echo $full_list`; do
+    file=`echo $full_line | awk 'BEGIN{FS=":"}{print $1}'`
+    echo "doing "$file 
+    cp $file $file.back
+    sed $sed_string $file.back > $file
+    rm -f $file.back
+done

--- a/bin/destruct_test_distribution.bash
+++ b/bin/destruct_test_distribution.bash
@@ -12,7 +12,7 @@
 # location of tar files for external distributions,
 # currently (and for the foreseeable future!)
 #
-#   http://www.maths.manchester.ac.uk/~oomphlib/oomph-lib_external_distfiles/
+#   https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/
 #
 # should probably be handled the same way but aren't
 # yet. Works fine on leylandii/vummath.
@@ -102,28 +102,28 @@ fi
 
 #------------------------------------------------------
 # Name of trilinos tar file at 
-# http://www.maths.manchester.ac.uk/~oomphlib/oomph-lib_external_distfiles/
+# https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/
 # [update]
 #------------------------------------------------------
 trilinos_tar_file=trilinos-11.8.1-Source.tar.gz
 
 #------------------------------------------------------
 # Name of hypre tar file at 
-# http://www.maths.manchester.ac.uk/~oomphlib/oomph-lib_external_distfiles/
+# https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/
 # [update]
 #------------------------------------------------------
 hypre_tar_file=hypre-2.0.0.tar.gz
 
 #------------------------------------------------------
 # Name of mumps tar file at 
-# http://www.maths.manchester.ac.uk/~oomphlib/oomph-lib_external_distfiles/
+# https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/
 # [update]
 #------------------------------------------------------
 mumps_tar_file=MUMPS_4.10.0.tar.gz
 
 #------------------------------------------------------
 # Name of scalapack tar file at 
-# http://www.maths.manchester.ac.uk/~oomphlib/oomph-lib_external_distfiles/
+# https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/
 # [update]
 #------------------------------------------------------
 scalapack_tar_file=scalapack_installer.tgz
@@ -134,7 +134,7 @@ echo "CHECKING EXTERNAL DISTRIBUTIONS"
 echo "==============================="
 echo " " 
 
-full_url=http://www.maths.manchester.ac.uk/~oomphlib/oomph-lib_external_distfiles/$trilinos_tar_file 
+full_url=https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/$trilinos_tar_file 
 echo "Tar file: "
 echo " "
 echo "     "$full_url
@@ -149,7 +149,7 @@ else
 fi
 echo " "
 
-full_url=http://www.maths.manchester.ac.uk/~oomphlib/oomph-lib_external_distfiles/$hypre_tar_file 
+full_url=https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/$hypre_tar_file 
 echo "Tar file: "
 echo " "
 echo "     "$full_url
@@ -164,7 +164,7 @@ else
 fi
 echo " "
 
-full_url=http://www.maths.manchester.ac.uk/~oomphlib/oomph-lib_external_distfiles/$mumps_tar_file 
+full_url=https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/$mumps_tar_file 
 echo "Tar file: "
 echo " "
 echo "     "$full_url
@@ -179,7 +179,7 @@ else
 fi
 echo " "
 
-full_url=http://www.maths.manchester.ac.uk/~oomphlib/oomph-lib_external_distfiles/$scalapack_tar_file 
+full_url=https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/$scalapack_tar_file 
 echo "Tar file: "
 echo " "
 echo "     "$full_url
@@ -257,7 +257,7 @@ for do_mpi in 0 1; do
                 # TRILINOS [update version number]
                 #---------------------------------
                 echo "cd external_distributions/trilinos/  " >> build_script.bash 
-                echo " wget http://www.maths.manchester.ac.uk/~oomphlib/oomph-lib_external_distfiles/"$trilinos_tar_file >> build_script.bash 
+                echo " wget https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/"$trilinos_tar_file >> build_script.bash 
                 echo "if [ ! -e $trilinos_tar_file ]; then  " >> build_script.bash 
                 echo "   echo \"Download of trilinos tar file failed\"  " >> build_script.bash 
                 echo "   exit  " >> build_script.bash 
@@ -269,7 +269,7 @@ for do_mpi in 0 1; do
                 # HYPRE [updateversion number]
                 #-----------------------------
                 echo "cd external_distributions/hypre" >> build_script.bash 
-                echo "wget http://www.maths.manchester.ac.uk/~oomphlib/oomph-lib_external_distfiles/"$hypre_tar_file >> build_script.bash 
+                echo "wget https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/"$hypre_tar_file >> build_script.bash 
                 echo "if [ ! -e $hypre_tar_file ]; then" >> build_script.bash 
                 echo "    echo \"Download of hypre tar file failed\" " >> build_script.bash 
                 echo "    exit" >> build_script.bash 
@@ -281,8 +281,8 @@ for do_mpi in 0 1; do
                 # MUMPS/SCALAPACK [update version number]
                 #----------------------------------------
                 echo "cd external_distributions/mumps_and_scalapack" >> build_script.bash 
-                echo "wget http://www.maths.manchester.ac.uk/~oomphlib/oomph-lib_external_distfiles/"$scalapack_tar_file >> build_script.bash 
-                echo "wget http://www.maths.manchester.ac.uk/~oomphlib/oomph-lib_external_distfiles/"$mumps_tar_file >> build_script.bash 
+                echo "wget https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/"$scalapack_tar_file >> build_script.bash 
+                echo "wget https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/"$mumps_tar_file >> build_script.bash 
                 echo "if [ ! -e $mumps_tar_file ]; then" >> build_script.bash 
                 echo "    echo \"Download of mumps tar file failed\" " >> build_script.bash 
                 echo "    exit" >> build_script.bash 

--- a/bin/get_external_distribution_tar_files.bash
+++ b/bin/get_external_distribution_tar_files.bash
@@ -13,7 +13,7 @@ echo " "
 
 # Do we have the interweb?
 # from https://stackoverflow.com/questions/929368/how-to-test-an-internet-connection-with-bash
-url=http://oomph-lib.maths.man.ac.uk/oomph-lib_external_distfiles/
+url=https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/
 wget -q --spider $url
 if [ $? -eq 0 ]; then
     echo "Yay!"
@@ -64,7 +64,7 @@ tar_file=trilinos-11.8.1-Source.tar.gz
 if [ -e $tar_file ]; then
     echo "        tar file "$tar_file" already exists; not downloading it again!"
 else
-    wget http://oomph-lib.maths.man.ac.uk/oomph-lib_external_distfiles/$tar_file
+    wget https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/$tar_file
     if [ -e $tar_file ]; then
         echo "Success!"
     else
@@ -87,7 +87,7 @@ tar_file=hypre-2.0.0.tar.gz
 if [ -e $tar_file ]; then
     echo "        tar file "$tar_file" already exists; not downloading it again!"
 else
-    wget http://oomph-lib.maths.man.ac.uk/oomph-lib_external_distfiles/$tar_file
+    wget https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/$tar_file
     if [ -e $tar_file ]; then
         echo "Success!"
     else
@@ -112,7 +112,7 @@ for tar_file in `echo $tar_file_list`; do
     if [ -e $tar_file ]; then
         echo "        tar file "$tar_file" already exists; not downloading it again!"
     else
-        wget http://oomph-lib.maths.man.ac.uk/oomph-lib_external_distfiles/$tar_file
+        wget https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/$tar_file
         if [ -e $tar_file ]; then
             echo "Success!"
         else

--- a/bin/move_external_libraries_and_distributions_to_permanent_location.bash
+++ b/bin/move_external_libraries_and_distributions_to_permanent_location.bash
@@ -208,7 +208,7 @@ echo " "
 
 # Do we have the interweb?
 # from https://stackoverflow.com/questions/929368/how-to-test-an-internet-connection-with-bash
-url=http://oomph-lib.maths.man.ac.uk/oomph-lib_external_distfiles/
+url=https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/
 wget -q --spider $url
 if [ $? -eq 0 ]; then
     echo "Yay!"
@@ -259,7 +259,7 @@ tar_file=trilinos-11.8.1-Source.tar.gz
 if [ -e $tar_file ]; then
     echo "        tar file "$tar_file" already exists; not downloading it again!"
 else
-    wget http://oomph-lib.maths.man.ac.uk/oomph-lib_external_distfiles/$tar_file
+    wget https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/$tar_file
     if [ -e $tar_file ]; then
         echo "Success!"
     else
@@ -282,7 +282,7 @@ tar_file=hypre-2.0.0.tar.gz
 if [ -e $tar_file ]; then
     echo "        tar file "$tar_file" already exists; not downloading it again!"
 else
-    wget http://oomph-lib.maths.man.ac.uk/oomph-lib_external_distfiles/$tar_file
+    wget https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/$tar_file
     if [ -e $tar_file ]; then
         echo "Success!"
     else
@@ -307,7 +307,7 @@ for tar_file in `echo $tar_file_list`; do
     if [ -e $tar_file ]; then
         echo "        tar file "$tar_file" already exists; not downloading it again!"
     else
-        wget http://oomph-lib.maths.man.ac.uk/oomph-lib_external_distfiles/$tar_file
+        wget https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/$tar_file
         if [ -e $tar_file ]; then
             echo "Success!"
         else


### PR DESCRIPTION
Specifically:

- third party distributions (hypre, trilinos and mumps) tar files
now live at https://personal.maths.manchester.ac.uk/oomphlib/oomph-lib_external_distfiles/

- Have also added tar file with bleeding edge doxygen distribution to that site, so we don't rely on it being kept available on the doxygen webpage.