### PR TITLE
Fix static hosted picture show using js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,7 @@ html/
 *header.html
 *txt_doxygenified.*
 doc/index/oomph_index.txt
-doc/picture_show/rotate_gifs.php
+doc/picture_show/rotate_gifs.js
 doc/preconditioners/lgr_navier_stokes/lgr_navier_stokes_old.txt
 doc/preconditioners/lgr_navier_stokes/lgr_navier_stokes_old2.txt
 *.swo

--- a/doc/picture_show/Makefile.am
+++ b/doc/picture_show/Makefile.am
@@ -3,10 +3,10 @@
 # *.txt file, therefore there's no ordinary target for
 # the automated makefilery.
 
-all: rotate_gifs.php
+all: rotate_gifs.js
 
-# How to create the php file:
-rotate_gifs.php:
+# How to create the js file:
+rotate_gifs.js:
 	./turn_into_rotation_instructions.sh
 
 # Additional files to be included into the documenation
@@ -15,5 +15,5 @@ EXTRA_DIST = turn_into_rotation_instructions.sh index.html
 
 # Additional files to clean (there's already a clean-local target in
 # the generic makefile included above).
-CLEANFILES=rotate_gifs.php
+CLEANFILES=rotate_gifs.js
 

--- a/doc/picture_show/index.html
+++ b/doc/picture_show/index.html
@@ -118,13 +118,28 @@ This page shows random figures from oomph-lib's documentation.
 Click on the figure to find out what it's all about. 
 Reload the page to load a different figure.
 
-<!-- jQuery for Bootstrap and Doxygen -->
-  <script src="../js/jquery-1.12.0.min.js"></script>
-  <!-- Minified boostrap plugins-->
-  <script src="../js/bootstrap.js"></script>
+<h2 id="random_picture_title" style="text-align:center;">$title</h2>
+<a id="random_picture_link">
+  <img id="random_picture_src" class="img-responsive centered">
+</a>
 
-<script language="JavaScript" src="https://matthiasheilmanchester.github.io/oomph-lib/doc/picture_show/rotate_gifs.php">
-</script>
+<!-- jQuery for Bootstrap and Doxygen -->
+<script src="../js/jquery-1.12.0.min.js"></script>
+<!-- Minified boostrap plugins-->
+<script src="../js/bootstrap.js"></script>
+
+<script src="rotate_gifs.js"></script>
+
+<script>
+  // Pick random figure
+  var figure = figures[Math.floor(Math.random() * figures.length)]
+
+  // Assign properties to HTML
+  document.getElementById("random_picture_title").innerHTML = figure.title;
+  document.getElementById("random_picture_src").src = figure.gif;
+  document.getElementById("random_picture_link").href = figure.link;
+</script> 
+
 </div>
 
 


### PR DESCRIPTION
The picture show is currently broken because it uses a PHP script. PHP scripts require the web server to be running PHP, this is not the case for gh-pages and github.io. One way to fix this is to move the logic to the client side and use JavaScript instead of PHP.