### PR TITLE
[PATCH] Ubuntu MPI self-tests don't actually install MUMPS/ScaLAPACK

### DIFF
--- a/.github/workflows/self-tests-ubuntu.yaml
+++ b/.github/workflows/self-tests-ubuntu.yaml
@@ -12,7 +12,7 @@ jobs:
         # MPI case, respectively
         mpi_options: [
           {enable: false, config_file: default},
-          {enable: true,  config_file: mpi_default_ci}
+          {enable: true, config_file: mpi_default_ci}
         ]
 
     runs-on: ubuntu-latest
@@ -26,10 +26,47 @@ jobs:
       - name: Install MPI requirements (if required)
         if: ${{ matrix.mpi_options.enable == true }}
         run: sudo apt-get install openmpi-bin libopenmpi-dev
-        
+
+      - name: Find MPI include directory path, if required
+        if: ${{ matrix.mpi_options.enable == true }}
+        run: |
+          printf "\nFULL MPICC SHOWME:\n    $(mpicc --showme)\n\n"
+
+          found_mpi_header=0
+          for pth in $(mpicc --showme:incdirs); do
+            printf "INCLUDE PATH: $pth\n"
+            printf "SEARCHING FOR MPI.H: "
+            if [ ! -z $(find "$pth" -iname mpi.h) ]; then
+              printf "...found mpi.h!\n"
+              echo "::set-output name=mpi_h_loc::$pth"
+              printf "EXPORTING INCLUDE PATH!\n"
+              found_mpi_header=1
+              break
+            else
+              printf "...couldn't find mpi.h!\n"
+              printf "FILES INSIDE MPI INCLUDE DIRECTORY:\n\n"
+              ls -l "$pth"
+              printf "\n"
+            fi
+          done
+          if [ ${found_mpi_header} -eq 0 ]; then
+            exit 1
+          fi
+        id: find_mpi_header
+
+      - name: Add MPI include path into config file
+        if: ${{ matrix.mpi_options.enable == true }}
+        run: |
+          printf '%s\n' '--with-mpi-include-directory=${{ steps.find_mpi_header.outputs.mpi_h_loc }}' >> config/configure_options/${{ matrix.mpi_options.config_file }} && \
+          ( export LC_ALL=C; sort -o config/configure_options/${{ matrix.mpi_options.config_file }} config/configure_options/${{ matrix.mpi_options.config_file }})
+
+      - name: Print updated config file (without comments)
+        if: ${{ matrix.mpi_options.enable == true }}
+        run: cat config/configure_options/${{ matrix.mpi_options.config_file }} | sed '/^#/d'
+
       - name: Get external distribution tar files (if MPI is used)
         if: ${{ matrix.mpi_options.enable == true }}
-        run: bin/get_external_distribution_tar_files.bash 
+        run: bin/get_external_distribution_tar_files.bash
 
       - name: Build
         run: |


### PR DESCRIPTION
## Problem

@MatthiasHeilManchester spotted that MUMPS and ScaLAPACK weren't actually installed during the Ubuntu MPI self-tests. Example [here](https://github.com/oomph-lib/oomph-lib/runs/4598608734?check_suite_focus=true). Below is a snippet of the output during the "Build" step showing why the issue arises; the build can't find `mpi.h`.

```bash
161 mpi include directory (the directory that contains mpi.h) 
162 has been specified with --with-mpi-include-directory
163 therefore I can do mumps/scalapack build from source
164 Not found mpi.h for scalapack build
165 Did not find mpi.h in  for scalapack build
166 Found MUMPS_4.10.0.tar.gz
167 Found scalapack_installer.tgz
168 Not doing mumps/scalapack build because location of mpi.h file not specified
```

## Solution 

I've added a step to the workflow to find the MPI include directory (specifically the one containing the `mpi.h` file) using `mpicc --showme:incdirs`. The GitHub runner has two include directories so we have to loop over them to find the directory we want. (Only one of these directories actually holds the `mpi.h` header.) The MPI header include path then gets passed to `oomph-lib` using the `--with-mpi-include-directory` flag, which is added to the MPI config file. The additional "Print updated config file (without comments)" step is there to help with debugging if anything goes wrong in the future.

## Self-test

- [![Ubuntu self-tests](https://github.com/puneetmatharu/oomph-lib/actions/workflows/self-tests-ubuntu.yaml/badge.svg?branch=patch-ubuntu-mpi-workflow-not-finding-mpi-h)](https://github.com/puneetmatharu/oomph-lib/actions/runs/1630347303)
