### PR TITLE
Small bug fix

### DIFF
--- a/src/meshes/simple_cubic_mesh.template.h
+++ b/src/meshes/simple_cubic_mesh.template.h
@@ -119,7 +119,7 @@ namespace oomph
     /// Access function for number of elements in y directions
     const unsigned& nz() const
     {
-      return Nx;
+      return Nz;
     }
 
   protected:


### PR DESCRIPTION
Hi oomph-lib team,

I want to propose a minor bug fix to oomph-lib: 
SimpleCubicMesh::nz() should return Nz, not Nx

Regards,
Thomas

P.S.: I'm new to git, so let me know if this is the right way to do it.