### PR TITLE
Test for Python3 instead of Python2 in configure.ac and suppress CGAL building in MacOS config. files

### DIFF
--- a/config/configure_options/mac_osx_debug
+++ b/config/configure_options/mac_osx_debug
@@ -86,6 +86,9 @@
 #              used. autoconf should automatically detect any 
 #              other libraries.
 #=====================================================================
+# Disable the build of CGAL and its underlying third party distributions
+--enable-suppress-cgal-build
+
 --enable-suppress-doc
 --enable-symbolic-links-for-headers
 --disable-shared

--- a/config/configure_options/mac_osx_mpi_debug
+++ b/config/configure_options/mac_osx_mpi_debug
@@ -86,6 +86,9 @@
 #              used. autoconf should automatically detect any 
 #              other libraries.
 #=====================================================================
+# Disable the build of CGAL and its underlying third party distributions
+--enable-suppress-cgal-build
+
 --enable-suppress-doc
 --enable-symbolic-links-for-headers
 --disable-shared

--- a/config/configure_options/mac_osx_paranoid_debug_range_checking
+++ b/config/configure_options/mac_osx_paranoid_debug_range_checking
@@ -86,6 +86,9 @@
 #              used. autoconf should automatically detect any 
 #              other libraries.
 #=====================================================================
+# Disable the build of CGAL and its underlying third party distributions
+--enable-suppress-cgal-build
+
 --enable-suppress-doc
 --enable-symbolic-links-for-headers
 --disable-shared

--- a/configure.ac
+++ b/configure.ac
@@ -572,7 +572,7 @@ AM_CONDITIONAL(HAVE_PDF_LATEX, test x$have_pdf_latex = xtrue)
 
 # Do we have python installed?
 #-----------------------------
-AC_CHECK_PROG(have_python,python,true,false)
+AC_CHECK_PROG(have_python,python3,true,false)
 if test x$have_python = xfalse; then \
   echo " "; \
   echo "================================================================="; \


### PR DESCRIPTION
## Description

configure.ac edited such that oomph-lib checks for Python3 now.

## Self-tests

- [![Ubuntu self-tests](https://github.com/Rupinder99234/oomph-lib/actions/workflows/self-tests-ubuntu.yaml/badge.svg?branch=fix-macos-build)](https://github.com/Rupinder99234/oomph-lib/actions/workflows/self-tests-ubuntu.yaml)
- [![macOS self-tests](https://github.com/Rupinder99234/oomph-lib/actions/workflows/self-tests-macos.yaml/badge.svg?branch=fix-macos-build)](https://github.com/Rupinder99234/oomph-lib/actions/workflows/self-tests-macos.yaml)