### PR TITLE
Amend comments on output functions of Foeppl-von Karman elements

### DIFF
--- a/src/axisym_displ_based_foeppl_von_karman/axisym_displ_based_fvk_elements.cc
+++ b/src/axisym_displ_based_foeppl_von_karman/axisym_displ_based_fvk_elements.cc
@@ -311,7 +311,7 @@ namespace oomph
 
   //======================================================================
   /// Output function:
-  ///   r, w, sigma_r_r, sigma_phi_phi
+  ///   r, w, u, sigma_r_r, sigma_phi_phi
   /// nplot points
   //======================================================================
   void AxisymFoepplvonKarmanEquations::output(std::ostream& outfile,
@@ -345,7 +345,7 @@ namespace oomph
 
   //======================================================================
   /// C-style output function:
-  ///   r,w
+  ///   r,w,u
   /// nplot points
   //======================================================================
   void AxisymFoepplvonKarmanEquations::output(FILE* file_pt,

--- a/src/axisym_displ_based_foeppl_von_karman/axisym_displ_based_fvk_elements.h
+++ b/src/axisym_displ_based_foeppl_von_karman/axisym_displ_based_fvk_elements.h
@@ -120,7 +120,7 @@ namespace oomph
       output(outfile, n_plot);
     }
 
-    /// Output FE representation of soln: r,w,sigma_r_r,sigma_phi_phi
+    /// Output FE representation of soln: r,w,u,sigma_r_r,sigma_phi_phi
     /// at n_plot plot points
     void output(std::ostream& outfile, const unsigned& n_plot);
 
@@ -431,14 +431,14 @@ namespace oomph
 
 
     /// Output function:
-    ///  r,w,sigma_r_r,sigma_phi_phi
+    ///  r,w,u,sigma_r_r,sigma_phi_phi
     void output(std::ostream& outfile)
     {
       AxisymFoepplvonKarmanEquations::output(outfile);
     }
 
     ///  Output function:
-    ///   r,w,sigma_r_r,sigma_phi_phi at n_plot plot points
+    ///   r,w,u,sigma_r_r,sigma_phi_phi at n_plot plot points
     void output(std::ostream& outfile, const unsigned& n_plot)
     {
       AxisymFoepplvonKarmanEquations::output(outfile, n_plot);


### PR DESCRIPTION
Document the output of the radial displacement in the appropriate output() functions of the AxisymFoepplVonKarmanEquations and AxisymFoepplVonKarmanElements classes.