### PR TITLE
Fix a bug in DiskTetMeshFacetedSurface (defined in tetmesh_faceted_surfaces.h) regarding the nodes of boundary elements

### DIFF
--- a/demo_drivers/meshing/adaptive_tet_meshes/tetmesh_faceted_surfaces.h
+++ b/demo_drivers/meshing/adaptive_tet_meshes/tetmesh_faceted_surfaces.h
@@ -493,8 +493,8 @@ public:
    Tri_mesh_pt = new
     TriangleMesh<TPoissonElement<2,2> >(triangle_mesh_parameters);
 
-   // Loop over all boundary elements and rotate their nodes so that
-   // the first two nodes are on the boundary
+   // Loop over all outer boundary elements and rotate their nodes so that
+   // the first two nodes are on the outer boundary
    std::map<FiniteElement*,bool> is_on_boundary;
    for (unsigned b=0;b<2;b++)
     {
@@ -506,13 +506,12 @@ public:
        for (unsigned j=0;j<3;j++)
         {
          Node* nod_pt=el_pt->node_pt(j);
-         if (nod_pt->is_on_boundary()) count++;
+         if (nod_pt->is_on_boundary(b)) count++;
         }
        if (count==2)
         {
          is_on_boundary[el_pt]=true;
-         if ((el_pt->node_pt(0)->is_on_boundary())&&
-             (el_pt->node_pt(1)->is_on_boundary()))
+         if (!el_pt->node_pt(2)->is_on_boundary(b))
           {
            // fine
           }
@@ -522,13 +521,13 @@ public:
            Node* nod0_pt=el_pt->node_pt(0);
            Node* nod1_pt=el_pt->node_pt(1);
            Node* nod2_pt=el_pt->node_pt(2);
-           if (!el_pt->node_pt(0)->is_on_boundary())
+           if (!el_pt->node_pt(0)->is_on_boundary(b))
             {
              el_pt->node_pt(0)=nod1_pt;
              el_pt->node_pt(1)=nod2_pt;
              el_pt->node_pt(2)=nod0_pt;
             }
-           else if (!el_pt->node_pt(1)->is_on_boundary())
+           else if (!el_pt->node_pt(1)->is_on_boundary(b))
             {
              el_pt->node_pt(0)=nod2_pt;
              el_pt->node_pt(1)=nod0_pt;

--- a/demo_drivers/meshing/adaptive_tet_meshes/tetmesh_faceted_surfaces.h
+++ b/demo_drivers/meshing/adaptive_tet_meshes/tetmesh_faceted_surfaces.h
@@ -511,7 +511,7 @@ public:
        if (count==2)
         {
          is_on_boundary[el_pt]=true;
-         if (!el_pt->node_pt(2)->is_on_boundary(b))
+         if (!(el_pt->node_pt(2)->is_on_boundary(b)))
           {
            // fine
           }
@@ -521,13 +521,13 @@ public:
            Node* nod0_pt=el_pt->node_pt(0);
            Node* nod1_pt=el_pt->node_pt(1);
            Node* nod2_pt=el_pt->node_pt(2);
-           if (!el_pt->node_pt(0)->is_on_boundary(b))
+           if (!(el_pt->node_pt(0)->is_on_boundary(b)))
             {
              el_pt->node_pt(0)=nod1_pt;
              el_pt->node_pt(1)=nod2_pt;
              el_pt->node_pt(2)=nod0_pt;
             }
-           else if (!el_pt->node_pt(1)->is_on_boundary(b))
+           else if (!(el_pt->node_pt(1)->is_on_boundary(b)))
             {
              el_pt->node_pt(0)=nod2_pt;
              el_pt->node_pt(1)=nod0_pt;


### PR DESCRIPTION
## Problem

In `DiskTetMeshFacetedSurface`, we count the boundary nodes of an element on the outer boundary to check there are only two, but an element may have all three nodes on boundaries since there is an internal annular boundary. A similar issue arises when cycling nodes such that nodes of index 2 aren't on the boundary. 

## Solution

The above issues were fixed by checking that a node is on the outer boundary rather than on a boundary.

N.B. This patch only affects the `meshing/adaptive_tet_meshes` self-test, which has passed; see linked tests below.

## Self-tests

- [![Ubuntu self-tests](https://github.com/RupinderM/oomph-lib/actions/workflows/self-tests-ubuntu.yaml/badge.svg?branch=fix-bug)](https://github.com/RupinderM/oomph-lib/actions/workflows/self-tests-ubuntu.yaml)
- [![macOS self-tests](https://github.com/RupinderM/oomph-lib/actions/workflows/self-tests-macos.yaml/badge.svg?branch=fix-bug)](https://github.com/RupinderM/oomph-lib/actions/workflows/self-tests-macos.yaml)