### PR TITLE
Fpdiff.py update

### DIFF
--- a/bin/fpdiff.py
+++ b/bin/fpdiff.py
@@ -80,6 +80,9 @@ def fpdiff_helper(filename1,filename2,relative_error,small,
  # handle the error and so we shouldn't do anything weird here).
  tmpfile1 = read_file(filename1)
  tmpfile2 = read_file(filename2)
+ # filename is passed for the selftest, etc.)
+ if len(tmpfile1) == 0:
+  return 1
 
  #Find the number of lines in each file
  n1 = len(tmpfile1)

--- a/bin/fpdiff.py
+++ b/bin/fpdiff.py
@@ -80,11 +80,12 @@ def fpdiff_helper(filename1,filename2,relative_error,small,
  # handle the error and so we shouldn't do anything weird here).
  tmpfile1 = read_file(filename1)
  tmpfile2 = read_file(filename2)
- # this line catches the error when an empty selftest gold data file is 
+ # this line catches the error when an empty selftest reference data file is 
  # provided and will return a FAIL (e.g. wrong filename is passed for the selftest, etc.)
- if len(tmpfile1) == 0:
-  details_stream.write("\nWarning: gold data file %s is empty and will therefore be treated as a FAIL\n" % filename1)
-  return 1
+ for file_length, filename in [(len(tmpfile1), filename1), (len(tmpfile2), filename2)]:
+  if file_length == 0:
+   details_stream.write(f"\nWarning: file {filename} is empty and the test will therefore be treated as a FAIL\n")
+   return 1
 
  #Find the number of lines in each file
  n1 = len(tmpfile1)

--- a/bin/fpdiff.py
+++ b/bin/fpdiff.py
@@ -80,7 +80,8 @@ def fpdiff_helper(filename1,filename2,relative_error,small,
  # handle the error and so we shouldn't do anything weird here).
  tmpfile1 = read_file(filename1)
  tmpfile2 = read_file(filename2)
- # filename is passed for the selftest, etc.)
+ # this line catches the error when an empty selftest gold data file is 
+ # provided and will return a FAIL (e.g. wrong filename is passed for the selftest, etc.)
  if len(tmpfile1) == 0:
   return 1
 

--- a/bin/fpdiff.py
+++ b/bin/fpdiff.py
@@ -83,6 +83,7 @@ def fpdiff_helper(filename1,filename2,relative_error,small,
  # this line catches the error when an empty selftest gold data file is 
  # provided and will return a FAIL (e.g. wrong filename is passed for the selftest, etc.)
  if len(tmpfile1) == 0:
+  details_stream.write("\nWarning: gold data file %s is empty and will therefore be treated as a FAIL\n" % filename1)
   return 1
 
  #Find the number of lines in each file

--- a/bin/fpdiff.py
+++ b/bin/fpdiff.py
@@ -80,8 +80,7 @@ def fpdiff_helper(filename1,filename2,relative_error,small,
  # handle the error and so we shouldn't do anything weird here).
  tmpfile1 = read_file(filename1)
  tmpfile2 = read_file(filename2)
- # this line catches the error when an empty selftest reference data file is 
- # provided and will return a FAIL (e.g. wrong filename is passed for the selftest, etc.)
+ # this line catches the error when an empty selftest reference data file is provided and will return a FAIL
  for file_length, filename in [(len(tmpfile1), filename1), (len(tmpfile2), filename2)]:
   if file_length == 0:
    details_stream.write(f"\nWarning: file {filename} is empty and the test will therefore be treated as a FAIL\n")


### PR DESCRIPTION


Dear Andrew,

I updated fpdiff.py accordingly to our changes in MercuryDPM.
We updated our selftests to also output the directory they are running in at terminal level and this resulted in putting the path+testname as filename. Therefore, fpdiff compared two empty files which lead to a passed selftest. This small fix should now catch if the selftest gold data isn't found and will return a FAILED (return 1) for those tests.

kind regards
Timo
