### PR TITLE
Fix heisenbug dec 2023

### DIFF
--- a/config/configure_options/private_configure_options/xeon_biolaptop_mpi_paranoid_debug_range_check
+++ b/config/configure_options/private_configure_options/xeon_biolaptop_mpi_paranoid_debug_range_check
@@ -107,9 +107,9 @@
 --with-mpi-self-tests-variablenp="mpirun -np OOMPHNP"
 --with-gmsh-self-tests="/home/matthias/gmsh/gmsh-4.12.0-source/build/gmsh"
 --with-mpi-include-directory=/usr/lib/x86_64-linux-gnu/openmpi/include
-CXXFLAGS="-O3 -Wall -std=c++11"
-CFLAGS="-O3"
-FFLAGS="-O3"
+CXXFLAGS="-g -DPARANOID -DRANGE_CHECKING -Wall -std=c++11"
+CFLAGS="-g"
+FFLAGS="-g"
 FFLAGS_NO_OPT="-O0"
 CXX=mpic++
 CC=mpicc

--- a/demo_drivers/mpi/distribution/two_d_unstructured_adaptive_poisson/validate.sh
+++ b/demo_drivers/mpi/distribution/two_d_unstructured_adaptive_poisson/validate.sh
@@ -155,7 +155,7 @@ echo $folder_distribution_file_flag $folder_distribution_file_value
 # the existence of the new directory
 sleep 5
 
-$MPI_RUN_ON_NP_COMMAND --output-filename OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np2_square ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np2_square_from_screen
+$MPI_RUN_ON_NP_COMMAND  ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np2_square_from_screen
 echo "done"
 echo " " >> validation.log
 echo "two_d_parallel_unstructured_adaptive_poisson (2 processors) SQUARE domain validation" >> validation.log
@@ -203,7 +203,7 @@ echo $folder_distribution_file_flag $folder_distribution_file_value
 # the existence of the new directory
 sleep 5
 
-$MPI_RUN_ON_NP_COMMAND --output-filename OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np3_square ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np3_square_from_screen
+$MPI_RUN_ON_NP_COMMAND ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np3_square_from_screen
 echo "done"
 echo " " >> validation.log
 echo "two_d_parallel_unstructured_adaptive_poisson (3 processors) SQUARE domain validation" >> validation.log
@@ -251,7 +251,7 @@ echo $folder_distribution_file_flag $folder_distribution_file_value
 # the existence of the new directory
 sleep 5
 
-$MPI_RUN_ON_NP_COMMAND --output-filename OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np4_square ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np4_square_from_screen
+$MPI_RUN_ON_NP_COMMAND  ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np4_square_from_screen
 echo "done"
 echo " " >> validation.log
 echo "two_d_parallel_unstructured_adaptive_poisson (4 processors) SQUARE domain validation" >> validation.log
@@ -319,7 +319,7 @@ echo $folder_distribution_file_flag $folder_distribution_file_value
 # the existence of the new directory
 sleep 5
 
-$MPI_RUN_ON_NP_COMMAND --output-filename OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np2_half_circle ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np2_half_circle_from_screen
+$MPI_RUN_ON_NP_COMMAND  ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np2_half_circle_from_screen
 echo "done"
 echo " " >> validation.log
 echo "two_d_parallel_unstructured_adaptive_poisson (2 processors) HALF CIRCLE domain validation" >> validation.log
@@ -367,7 +367,7 @@ echo $folder_distribution_file_flag $folder_distribution_file_value
 # the existence of the new directory
 sleep 5
 
-$MPI_RUN_ON_NP_COMMAND --output-filename OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np3_half_circle ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np3_half_circle_from_screen
+$MPI_RUN_ON_NP_COMMAND  ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np3_half_circle_from_screen
 echo "done"
 echo " " >> validation.log
 echo "two_d_parallel_unstructured_adaptive_poisson (3 processors) HALF CIRCLE domain validation" >> validation.log
@@ -415,7 +415,7 @@ echo $folder_distribution_file_flag $folder_distribution_file_value
 # the existence of the new directory
 sleep 5
 
-$MPI_RUN_ON_NP_COMMAND --output-filename OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np4_half_circle ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np4_half_circle_from_screen
+$MPI_RUN_ON_NP_COMMAND  ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np4_half_circle_from_screen
 echo "done"
 echo " " >> validation.log
 echo "two_d_parallel_unstructured_adaptive_poisson (4 processors) HALF CIRCLE domain validation" >> validation.log
@@ -483,7 +483,7 @@ echo $folder_distribution_file_flag $folder_distribution_file_value
 # the existence of the new directory
 sleep 5
 
-$MPI_RUN_ON_NP_COMMAND --output-filename OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np2_half_circle_internal_boundaries ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np2_half_circle_internal_boundaries_from_screen
+$MPI_RUN_ON_NP_COMMAND  ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np2_half_circle_internal_boundaries_from_screen
 echo "done"
 echo " " >> validation.log
 echo "two_d_parallel_unstructured_adaptive_poisson (2 processors) HALF_CIRCLE_INTERNAL_BOUNDARIES domain validation" >> validation.log
@@ -531,7 +531,7 @@ echo $folder_distribution_file_flag $folder_distribution_file_value
 # the existence of the new directory
 sleep 5
 
-$MPI_RUN_ON_NP_COMMAND --output-filename OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np3_half_circle_internal_boundaries ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np3_half_circle_internal_boundaries_from_screen
+$MPI_RUN_ON_NP_COMMAND ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np3_half_circle_internal_boundaries_from_screen
 echo "done"
 echo " " >> validation.log
 echo "two_d_parallel_unstructured_adaptive_poisson (3 processors) HALF_CIRCLE_INTERNAL_BOUNDARIES domain validation" >> validation.log
@@ -579,7 +579,7 @@ echo $folder_distribution_file_flag $folder_distribution_file_value
 # the existence of the new directory
 sleep 5
 
-$MPI_RUN_ON_NP_COMMAND --output-filename OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np4_half_circle_internal_boundaries ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np4_half_circle_internal_boundaries_from_screen
+$MPI_RUN_ON_NP_COMMAND  ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np4_half_circle_internal_boundaries_from_screen
 echo "done"
 echo " " >> validation.log
 echo "two_d_parallel_unstructured_adaptive_poisson (4 processors) HALF_CIRCLE_INTERNAL_BOUNDARIES domain validation" >> validation.log
@@ -647,7 +647,7 @@ echo $folder_distribution_file_flag $folder_distribution_file_value
 # the existence of the new directory
 sleep 5
 
-$MPI_RUN_ON_NP_COMMAND --output-filename OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np2_complex_holes ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np2_complex_holes_from_screen
+$MPI_RUN_ON_NP_COMMAND  ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np2_complex_holes_from_screen
 echo "done"
 echo " " >> validation.log
 echo "two_d_parallel_unstructured_adaptive_poisson (2 processors) COMPLEX_HOLES domain validation" >> validation.log
@@ -695,7 +695,7 @@ echo $folder_distribution_file_flag $folder_distribution_file_value
 # the existence of the new directory
 sleep 5
 
-$MPI_RUN_ON_NP_COMMAND --output-filename OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np3_complex_holes ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np3_complex_holes_from_screen
+$MPI_RUN_ON_NP_COMMAND  ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np3_complex_holes_from_screen
 echo "done"
 echo " " >> validation.log
 echo "two_d_parallel_unstructured_adaptive_poisson (3 processors) COMPLEX_HOLES domain validation" >> validation.log
@@ -743,7 +743,7 @@ echo $folder_distribution_file_flag $folder_distribution_file_value
 # the existence of the new directory
 sleep 5
 
-$MPI_RUN_ON_NP_COMMAND --output-filename OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np4_complex_holes ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np4_complex_holes_from_screen
+$MPI_RUN_ON_NP_COMMAND ../two_d_parallel_unstructured_adaptive_poisson $sample_point_container_flag $domain_configuration_flag $domain_configuration_value $element_size_flag $element_size_value $max_adapt_flag $max_adapt_value $max_permitted_error_flag $max_permitted_error_value $min_permitted_error_flag $min_permitted_error_value $max_element_size_flag $max_element_size_value $min_element_size_flag $min_element_size_value $load_balance_flag $load_balance_value $folder_distribution_file_flag $folder_distribution_file_value > OUTPUT_two_d_parallel_unstructured_adaptive_poisson_np4_complex_holes_from_screen
 echo "done"
 echo " " >> validation.log
 echo "two_d_parallel_unstructured_adaptive_poisson (4 processors) COMPLEX_HOLES domain validation" >> validation.log

--- a/external_distributions/cgal/build_script.bash
+++ b/external_distributions/cgal/build_script.bash
@@ -125,6 +125,7 @@ build_opts="-DWITH_GMP=true \
             -DMPFR_INCLUDE_DIR=$mpfr_include \
             -DMPFR_LIBRARIES=$mpfr_actual_library \
             -DBOOST_INCLUDEDIR=$boost_include \
+            -DWITH_CGAL_Qt5=false \
             $src_dir"
 echo $build_opts
 cmake $build_opts

--- a/src/meshes/triangle_mesh.template.cc
+++ b/src/meshes/triangle_mesh.template.cc
@@ -6213,6 +6213,12 @@ namespace oomph
         }
 
         // --------------
+
+
+        
+         // Work-around for odd seg fault when calling MPI_Wait below.
+         MPI_Request my_request;
+         
         // Double data
         unsigned nflat_double_send = flat_double_send_packed_data.size();
         MPI_Isend(&nflat_double_send,
@@ -6221,8 +6227,8 @@ namespace oomph
                   send_proc,
                   3,
                   comm_pt->mpi_comm(),
-                  &request);
-
+                  &my_request);
+        
         unsigned nflat_double_receive = 0;
         MPI_Recv(&nflat_double_receive,
                  1,
@@ -6232,8 +6238,9 @@ namespace oomph
                  comm_pt->mpi_comm(),
                  &status);
 
-        MPI_Wait(&request, MPI_STATUS_IGNORE);
-
+         // this is where it used to die without separate MPI request
+         MPI_Wait(&my_request, MPI_STATUS_IGNORE);
+        
         if (nflat_double_send != 0)
         {
           MPI_Isend(&flat_double_send_packed_data[0],
@@ -6242,7 +6249,7 @@ namespace oomph
                     send_proc,
                     4,
                     comm_pt->mpi_comm(),
-                    &request);
+                    &my_request);
         }
 
         if (nflat_double_receive != 0)
@@ -6259,7 +6266,7 @@ namespace oomph
 
         if (nflat_double_send != 0)
         {
-          MPI_Wait(&request, MPI_STATUS_IGNORE);
+          MPI_Wait(&my_request, MPI_STATUS_IGNORE);
         }
         // --------------
 
@@ -34560,10 +34567,6 @@ namespace oomph
         this->copy_connection_information(polygon_pt->polyline_pt(p),
                                           tmp_curve_section_pt);
 
-        // Now update the polyline according to the new vertices but
-        // first check if the object is allowed to delete the representation
-        // or if it should be done by other object
-        bool delete_it_on_destructor = false;
 
         std::set<TriangleMeshCurveSection*>::iterator it =
           this->Free_curve_section_pt.find(polygon_pt->curve_section_pt(p));
@@ -34572,7 +34575,6 @@ namespace oomph
         {
           this->Free_curve_section_pt.erase(it);
           delete polygon_pt->curve_section_pt(p);
-          delete_it_on_destructor = true;
         }
 
         // ------------------------------------------------------------

--- a/src/meshes/triangle_mesh.template.cc
+++ b/src/meshes/triangle_mesh.template.cc
@@ -6215,10 +6215,9 @@ namespace oomph
         // --------------
 
 
-        
-         // Work-around for odd seg fault when calling MPI_Wait below.
-         MPI_Request my_request;
-         
+        // Work-around for odd seg fault when calling MPI_Wait below.
+        MPI_Request my_request;
+
         // Double data
         unsigned nflat_double_send = flat_double_send_packed_data.size();
         MPI_Isend(&nflat_double_send,
@@ -6228,7 +6227,7 @@ namespace oomph
                   3,
                   comm_pt->mpi_comm(),
                   &my_request);
-        
+
         unsigned nflat_double_receive = 0;
         MPI_Recv(&nflat_double_receive,
                  1,
@@ -6238,9 +6237,9 @@ namespace oomph
                  comm_pt->mpi_comm(),
                  &status);
 
-         // this is where it used to die without separate MPI request
-         MPI_Wait(&my_request, MPI_STATUS_IGNORE);
-        
+        // this is where it used to die without separate MPI request
+        MPI_Wait(&my_request, MPI_STATUS_IGNORE);
+
         if (nflat_double_send != 0)
         {
           MPI_Isend(&flat_double_send_packed_data[0],


### PR DESCRIPTION
- Work-around for bizarre MPI problem in distributed triangle meshes. Code used to 
seg fault when going into MPI_Wait if  oomph-lib was compiled with any 
optimisation, i.e. -O1 upwards.   ddd-based investigations unclear. Trial and error showed that
 passing a new (rather than re-used) MPI_Request object to that
 call (and the associated collective communications that it's
 waiting for) fixed the problem. Somewhat unsatisfactory and definitely
 one to keep an eye on...

ANDREW: Can you please clone my branch and check if it works on your machine too (either pre- or post-accept for this merge)

- A few more little tidies and modified the build machinery to explicity suppress Qt5-related builds in CGAL.

- Ubuntu passes cleanly

     https://github.com/MatthiasHeilManchester/oomph-lib/actions/runs/7346957076


- macos still has the usual failure in the elastic bretherton code

     https://github.com/MatthiasHeilManchester/oomph-lib/actions/runs/7346957077

