### PR TITLE
Remove pure virtual overrides from Z2 elements

### DIFF
--- a/src/generic/error_estimator.h
+++ b/src/generic/error_estimator.h
@@ -126,13 +126,6 @@ namespace oomph
     /// remain at the default value zero.
     virtual void get_Z2_compound_flux_indices(Vector<unsigned>& flux_index) {}
 
-    /// Number of vertex nodes in the element
-    virtual unsigned nvertex_node() const = 0;
-
-    /// Pointer to the j-th vertex node in the element. Needed for
-    /// efficient patch assmbly
-    virtual Node* vertex_node_pt(const unsigned& j) const = 0;
-
     /// Order of recovery shape functions
     virtual unsigned nrecovery_order() = 0;
 


### PR DESCRIPTION
Small commit removing the pure virtual overrides of the functions

    virtual unsigned nvertex_node() const = 0;
    virtual Node* vertex_node_pt(const unsigned& j) const = 0;

from the ElementWithZ2ErrorEstimator class, as both functions are already inherited from the FiniteElement base class as broken functions, such that, if they are ever used without being reimplemented, they throw an OomphLibError.

The default FiniteElement behaviour is sufficient to ensure the functions end up implemented before they are used, removing the pure virtual override prevents ambiguity in the case of multiple/diamond inheritance.

Self test results
[Ubuntu (passing)](https://github.com/AidanRetallick/oomph-lib/actions/runs/8309177458)
[Mac (passing)](https://github.com/AidanRetallick/oomph-lib/actions/runs/8309177455)