### PR TITLE
Minor fixes for the linear stability elements

### DIFF
--- a/src/linear_elasticity/Makefile.am
+++ b/src/linear_elasticity/Makefile.am
@@ -5,7 +5,8 @@
 # Define the sources
 sources =  \
 elasticity_tensor.cc linear_elasticity_elements.cc \
-refineable_linear_elasticity_elements.cc Tlinear_elasticity_elements.cc
+refineable_linear_elasticity_elements.cc Tlinear_elasticity_elements.cc \
+linear_elasticity_traction_elements.cc 
 
 # Include files which shouldn't be compiled
 incl_cc_files =
@@ -15,7 +16,7 @@ headers =  \
 elasticity_tensor.h linear_elasticity_elements.h \
 linear_elasticity_traction_elements.h \
 Tlinear_elasticity_elements.h \
-refineable_linear_elasticity_elements.h 
+refineable_linear_elasticity_elements.h
 
 
 # Template only files. These should be included in include directory

--- a/src/linear_elasticity/Tlinear_elasticity_elements.cc
+++ b/src/linear_elasticity/Tlinear_elasticity_elements.cc
@@ -37,6 +37,9 @@ namespace oomph
   //====================================================================
   // Force build of templates
   //====================================================================
+  template class TLinearElasticityElement<1, 2>;
+  template class TLinearElasticityElement<1, 3>;
+
   template class TLinearElasticityElement<2, 2>;
   template class TLinearElasticityElement<2, 3>;
   template class TLinearElasticityElement<2, 4>;

--- a/src/linear_elasticity/linear_elasticity_elements.cc
+++ b/src/linear_elasticity/linear_elasticity_elements.cc
@@ -719,6 +719,9 @@ namespace oomph
 
 
   // Instantiate the required elements
+  template class LinearElasticityEquationsBase<1>;
+  template class LinearElasticityEquations<1>;
+
   template class LinearElasticityEquationsBase<2>;
   template class LinearElasticityEquations<2>;
 

--- a/src/linear_elasticity/linear_elasticity_traction_elements.cc
+++ b/src/linear_elasticity/linear_elasticity_traction_elements.cc
@@ -1,0 +1,23 @@
+#include "linear_elasticity_traction_elements.h"
+
+namespace oomph
+{
+  //=======================================================================
+  /// Namespace containing the zero traction function for linear elasticity
+  /// traction elements
+  //=======================================================================
+  namespace LinearElasticityTractionElementHelper
+  {
+    void Zero_traction_fct(const double& time,
+                           const Vector<double>& x,
+                           const Vector<double>& N,
+                           Vector<double>& load)
+    {
+      unsigned n_dim = load.size();
+      for (unsigned i = 0; i < n_dim; i++)
+      {
+        load[i] = 0.0;
+      }
+    }
+  } // namespace LinearElasticityTractionElementHelper
+} // namespace oomph

--- a/src/linear_elasticity/linear_elasticity_traction_elements.h
+++ b/src/linear_elasticity/linear_elasticity_traction_elements.h
@@ -52,14 +52,7 @@ namespace oomph
     void Zero_traction_fct(const double& time,
                            const Vector<double>& x,
                            const Vector<double>& N,
-                           Vector<double>& load)
-    {
-      unsigned n_dim = load.size();
-      for (unsigned i = 0; i < n_dim; i++)
-      {
-        load[i] = 0.0;
-      }
-    }
+                           Vector<double>& load);
 
   } // namespace LinearElasticityTractionElementHelper
 


### PR DESCRIPTION
Force compilation of 1D elements. Needed for one of my projects but perhaps doesn't need to be included here.
Extract implementation to a cc file, as I was getting a "multiple definitions" error of this function.