### PR TITLE
Trigger the self tests to run once every month

### DIFF
--- a/.github/workflows/self-tests-macos.yaml
+++ b/.github/workflows/self-tests-macos.yaml
@@ -1,6 +1,13 @@
 name: macOS self-tests
 
-on: push
+# IMPORTANT: A schedule workflow action *must* be placed on the default branch
+# of the repository. Only then will it run as scheduled. It is also placed in a
+# queue when scheduled, so it may not run exactly at the requested time.
+on:
+  push: # Run when the branch is pushed to
+  schedule:
+    - cron: '0 0 1 * *'  # Every month on the first at midnight UTC
+  # Calculated using crontab.guru. See here: https://crontab.guru/#1_0_1_1_*.
 
 jobs:
   build:

--- a/.github/workflows/self-tests-ubuntu.yaml
+++ b/.github/workflows/self-tests-ubuntu.yaml
@@ -1,7 +1,13 @@
 name: Ubuntu self-tests
 
-on: push
-
+# IMPORTANT: A schedule workflow action *must* be placed on the default branch
+# of the repository. Only then will it run as scheduled. It is also placed in a
+# queue when scheduled, so it may not run exactly at the requested time.
+on:
+  push: # Run when the branch is pushed to
+  schedule:
+    - cron: '0 0 1 * *'  # Every month on the first at midnight UTC
+  # Calculated using crontab.guru. See here: https://crontab.guru/#1_0_1_1_*.
 jobs:
   build:
     strategy:


### PR DESCRIPTION
 In case any of the dependencies are updated in the meantime, such as the ubuntu-latest.
This means that the homepage readme will display up to date information (well within the last month) about the main branch of the repository.

The schedule run (similar to the update copyright run) only runs on the default (main) branch. So if people fork and create there own branches then only the main branches will run each month, to give an idea of the environmental cost. We should therefore merge the latest development branch into the main branch after this pull request, unless there is any good reason not too. (Or change this pull request to pull into main!) We should probably update the minor version in the tags too.

Perhaps there is a better way to implement this, and I am open to suggestions and happy to implement changes.
