### PR TITLE
Tidy up CMake usage

### DIFF
--- a/.github/workflows/build-and-publish-docs.yaml
+++ b/.github/workflows/build-and-publish-docs.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install requirements (minus doxygen)
+      - name: Install requirements
         run: sudo apt-get install cmake ninja-build doxygen texlive texlive-latex-extra texlive-font-utils
 
       - name: Check doxygen version

--- a/.github/workflows/test-build-of-docs.yaml
+++ b/.github/workflows/test-build-of-docs.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install requirements (minus doxygen)
+      - name: Install requirements
         run: sudo apt-get install cmake ninja-build doxygen texlive texlive-latex-extra texlive-font-utils
 
       - name: Check doxygen version

--- a/demo_drivers/CMakeLists.txt
+++ b/demo_drivers/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered demo_drivers subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(demo_drivers C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/FAQ/CMakeLists.txt
+++ b/demo_drivers/FAQ/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered FAQ subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(FAQ C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/advection_diffusion/CMakeLists.txt
+++ b/demo_drivers/advection_diffusion/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered advection_diffusion subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(advection_diffusion C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/advection_diffusion/two_d_adv_diff_SUPG/CMakeLists.txt
+++ b/demo_drivers/advection_diffusion/two_d_adv_diff_SUPG/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_adv_diff_SUPG subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_adv_diff_SUPG C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/advection_diffusion/two_d_adv_diff_adapt/CMakeLists.txt
+++ b/demo_drivers/advection_diffusion/two_d_adv_diff_adapt/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_adv_diff_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_adv_diff_adapt C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/advection_diffusion/two_d_adv_diff_flux_bc/CMakeLists.txt
+++ b/demo_drivers/advection_diffusion/two_d_adv_diff_flux_bc/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_adv_diff_flux_bc subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_adv_diff_flux_bc C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/advection_diffusion/two_d_variable_diff/CMakeLists.txt
+++ b/demo_drivers/advection_diffusion/two_d_variable_diff/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_variable_diff subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_variable_diff C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/all_foeppl_von_karman/CMakeLists.txt
+++ b/demo_drivers/all_foeppl_von_karman/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered all_foeppl_von_karman subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(all_foeppl_von_karman C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_advection_diffusion/CMakeLists.txt
+++ b/demo_drivers/axisym_advection_diffusion/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered axisym_advection_diffusion subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(axisym_advection_diffusion C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_advection_diffusion/pipe/CMakeLists.txt
+++ b/demo_drivers/axisym_advection_diffusion/pipe/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered pipe subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(pipe C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_displ_based_foeppl_von_karman/CMakeLists.txt
+++ b/demo_drivers/axisym_displ_based_foeppl_von_karman/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered axisym_displ_based_foeppl_von_karman subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(axisym_displ_based_foeppl_von_karman C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_foeppl_von_karman/CMakeLists.txt
+++ b/demo_drivers/axisym_foeppl_von_karman/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered axisym_foeppl_von_karman subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(axisym_foeppl_von_karman C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_linear_elasticity/CMakeLists.txt
+++ b/demo_drivers/axisym_linear_elasticity/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered axisym_linear_elasticity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(axisym_linear_elasticity C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_linear_elasticity/cylinder/CMakeLists.txt
+++ b/demo_drivers/axisym_linear_elasticity/cylinder/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered cylinder subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(cylinder C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_navier_stokes/CMakeLists.txt
+++ b/demo_drivers/axisym_navier_stokes/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered axisym_navier_stokes subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(axisym_navier_stokes C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_navier_stokes/axi_static_cap/CMakeLists.txt
+++ b/demo_drivers/axisym_navier_stokes/axi_static_cap/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered axi_static_cap subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(axi_static_cap C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_navier_stokes/counter_rotating_disks/CMakeLists.txt
+++ b/demo_drivers/axisym_navier_stokes/counter_rotating_disks/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered counter_rotating_disks subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(counter_rotating_disks C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_navier_stokes/fibre/CMakeLists.txt
+++ b/demo_drivers/axisym_navier_stokes/fibre/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fibre subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fibre C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_navier_stokes/rayleigh_instability/CMakeLists.txt
+++ b/demo_drivers/axisym_navier_stokes/rayleigh_instability/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered rayleigh_instability subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(rayleigh_instability C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_navier_stokes/rotating_ends/CMakeLists.txt
+++ b/demo_drivers/axisym_navier_stokes/rotating_ends/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered rotating_ends subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(rotating_ends C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_navier_stokes/single_layer_free_surface_axisym/CMakeLists.txt
+++ b/demo_drivers/axisym_navier_stokes/single_layer_free_surface_axisym/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered single_layer_free_surface_axisym subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(single_layer_free_surface_axisym C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_navier_stokes/spin_up/CMakeLists.txt
+++ b/demo_drivers/axisym_navier_stokes/spin_up/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered spin_up subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(spin_up C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_navier_stokes/torus/CMakeLists.txt
+++ b/demo_drivers/axisym_navier_stokes/torus/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered torus subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(torus C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_navier_stokes/two_fluid_spherical_cap/CMakeLists.txt
+++ b/demo_drivers/axisym_navier_stokes/two_fluid_spherical_cap/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_fluid_spherical_cap subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_fluid_spherical_cap C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_navier_stokes/two_layer_interface_axisym/CMakeLists.txt
+++ b/demo_drivers/axisym_navier_stokes/two_layer_interface_axisym/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_layer_interface_axisym subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_layer_interface_axisym C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_navier_stokes/unstructured_torus/CMakeLists.txt
+++ b/demo_drivers/axisym_navier_stokes/unstructured_torus/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_torus subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_torus C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_poroelasticity/CMakeLists.txt
+++ b/demo_drivers/axisym_poroelasticity/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered axisym_poroelasticity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(axisym_poroelasticity C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/axisym_poroelasticity/unstructured_two_d_curved/CMakeLists.txt
+++ b/demo_drivers/axisym_poroelasticity/unstructured_two_d_curved/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_two_d_curved subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_two_d_curved C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/beam/CMakeLists.txt
+++ b/demo_drivers/beam/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered beam subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(beam C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/beam/steady_ring/CMakeLists.txt
+++ b/demo_drivers/beam/steady_ring/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered steady_ring subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(steady_ring C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/beam/steady_third_ring/CMakeLists.txt
+++ b/demo_drivers/beam/steady_third_ring/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered steady_third_ring subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(steady_third_ring C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/beam/tensioned_string/CMakeLists.txt
+++ b/demo_drivers/beam/tensioned_string/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered tensioned_string subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(tensioned_string C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/beam/unsteady_ring/CMakeLists.txt
+++ b/demo_drivers/beam/unsteady_ring/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unsteady_ring subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unsteady_ring C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/bifurcation_tracking/CMakeLists.txt
+++ b/demo_drivers/bifurcation_tracking/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered bifurcation_tracking subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(bifurcation_tracking C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/biharmonic/CMakeLists.txt
+++ b/demo_drivers/biharmonic/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered biharmonic subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(biharmonic C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/biharmonic/two_d_biharmonic/CMakeLists.txt
+++ b/demo_drivers/biharmonic/two_d_biharmonic/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_biharmonic subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_biharmonic C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/darcy/CMakeLists.txt
+++ b/demo_drivers/darcy/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered darcy subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(darcy C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/darcy/unstructured_two_d_circle/CMakeLists.txt
+++ b/demo_drivers/darcy/unstructured_two_d_circle/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_two_d_circle subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_two_d_circle C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/eigenproblems/CMakeLists.txt
+++ b/demo_drivers/eigenproblems/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered eigenproblems subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(eigenproblems C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/eigenproblems/harmonic/CMakeLists.txt
+++ b/demo_drivers/eigenproblems/harmonic/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered harmonic subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(harmonic C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/eigenproblems/orr_sommerfeld/CMakeLists.txt
+++ b/demo_drivers/eigenproblems/orr_sommerfeld/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered orr_sommerfeld subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(orr_sommerfeld C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/extrude_quad_mesh_to_cube_mesh/CMakeLists.txt
+++ b/demo_drivers/extrude_quad_mesh_to_cube_mesh/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered extrude_quad_mesh_to_cube_mesh subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(extrude_quad_mesh_to_cube_mesh C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/flux_transport/CMakeLists.txt
+++ b/demo_drivers/flux_transport/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered flux_transport subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(flux_transport C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/flux_transport/advection/CMakeLists.txt
+++ b/demo_drivers/flux_transport/advection/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered advection subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(advection C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/flux_transport/euler/CMakeLists.txt
+++ b/demo_drivers/flux_transport/euler/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered euler subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(euler C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/foeppl_von_karman/CMakeLists.txt
+++ b/demo_drivers/foeppl_von_karman/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered foeppl_von_karman subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(foeppl_von_karman C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/foeppl_von_karman/circular_disk/CMakeLists.txt
+++ b/demo_drivers/foeppl_von_karman/circular_disk/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered circular_disk subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(circular_disk C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/fourier_decomposed_helmholtz/CMakeLists.txt
+++ b/demo_drivers/fourier_decomposed_helmholtz/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fourier_decomposed_helmholtz subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fourier_decomposed_helmholtz C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/fourier_decomposed_helmholtz/sphere_scattering/CMakeLists.txt
+++ b/demo_drivers/fourier_decomposed_helmholtz/sphere_scattering/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered sphere_scattering subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(sphere_scattering C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/generalised_newtonian_axisym_navier_stokes/CMakeLists.txt
+++ b/demo_drivers/generalised_newtonian_axisym_navier_stokes/CMakeLists.txt
@@ -12,7 +12,7 @@ list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE
         "Entered generalised_newtonian_axisym_navier_stokes subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(generalised_newtonian_axisym_navier_stokes C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/generalised_newtonian_axisym_navier_stokes/axisym_vibrating_shell/CMakeLists.txt
+++ b/demo_drivers/generalised_newtonian_axisym_navier_stokes/axisym_vibrating_shell/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered axisym_vibrating_shell subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(axisym_vibrating_shell C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/generalised_newtonian_navier_stokes/CMakeLists.txt
+++ b/demo_drivers/generalised_newtonian_navier_stokes/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered generalised_newtonian_navier_stokes subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(generalised_newtonian_navier_stokes C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/generalised_newtonian_navier_stokes/vibrating_shell/CMakeLists.txt
+++ b/demo_drivers/generalised_newtonian_navier_stokes/vibrating_shell/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered vibrating_shell subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(vibrating_shell C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/gzip/CMakeLists.txt
+++ b/demo_drivers/gzip/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered gzip subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(gzip C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/gzip/one_d_poisson/CMakeLists.txt
+++ b/demo_drivers/gzip/one_d_poisson/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered one_d_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(one_d_poisson C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/heat_transfer_and_melting/CMakeLists.txt
+++ b/demo_drivers/heat_transfer_and_melting/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered heat_transfer_and_melting subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(heat_transfer_and_melting C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/CMakeLists.txt
+++ b/demo_drivers/heat_transfer_and_melting/two_d_unsteady_heat_melt/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_unsteady_heat_melt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_unsteady_heat_melt C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/helmholtz/CMakeLists.txt
+++ b/demo_drivers/helmholtz/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered helmholtz subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(helmholtz C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/helmholtz/point_source/CMakeLists.txt
+++ b/demo_drivers/helmholtz/point_source/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered point_source subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(point_source C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/helmholtz/scattering/CMakeLists.txt
+++ b/demo_drivers/helmholtz/scattering/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered scattering subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(scattering C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/homogenisation/CMakeLists.txt
+++ b/demo_drivers/homogenisation/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered homogenisation subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(homogenisation C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/homogenisation/two_dim/CMakeLists.txt
+++ b/demo_drivers/homogenisation/two_dim/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_dim subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_dim C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/CMakeLists.txt
+++ b/demo_drivers/interaction/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered interaction subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(interaction C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/acoustic_fsi/CMakeLists.txt
+++ b/demo_drivers/interaction/acoustic_fsi/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered acoustic_fsi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(acoustic_fsi C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/elastic_bretherton/CMakeLists.txt
+++ b/demo_drivers/interaction/elastic_bretherton/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered elastic_bretherton subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(elastic_bretherton C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/fourier_decomposed_acoustic_fsi/CMakeLists.txt
+++ b/demo_drivers/interaction/fourier_decomposed_acoustic_fsi/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fourier_decomposed_acoustic_fsi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fourier_decomposed_acoustic_fsi C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/free_boundary_poisson/CMakeLists.txt
+++ b/demo_drivers/interaction/free_boundary_poisson/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered free_boundary_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(free_boundary_poisson C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/fsi_channel_seg_and_precond/CMakeLists.txt
+++ b/demo_drivers/interaction/fsi_channel_seg_and_precond/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fsi_channel_seg_and_precond subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fsi_channel_seg_and_precond C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/fsi_channel_with_leaflet/CMakeLists.txt
+++ b/demo_drivers/interaction/fsi_channel_with_leaflet/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fsi_channel_with_leaflet subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fsi_channel_with_leaflet C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/fsi_collapsible_channel/CMakeLists.txt
+++ b/demo_drivers/interaction/fsi_collapsible_channel/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fsi_collapsible_channel subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fsi_collapsible_channel C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/fsi_driven_cavity/CMakeLists.txt
+++ b/demo_drivers/interaction/fsi_driven_cavity/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fsi_driven_cavity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fsi_driven_cavity C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/fsi_osc_ring/CMakeLists.txt
+++ b/demo_drivers/interaction/fsi_osc_ring/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fsi_osc_ring subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fsi_osc_ring C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/linearised_fsi_pulsewave/CMakeLists.txt
+++ b/demo_drivers/interaction/linearised_fsi_pulsewave/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered linearised_fsi_pulsewave subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(linearised_fsi_pulsewave C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/linearised_poroelastic_fsi_pulsewave/CMakeLists.txt
+++ b/demo_drivers/interaction/linearised_poroelastic_fsi_pulsewave/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered linearised_poroelastic_fsi_pulsewave subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(linearised_poroelastic_fsi_pulsewave C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/pseudo_solid_collapsible_tube/CMakeLists.txt
+++ b/demo_drivers/interaction/pseudo_solid_collapsible_tube/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered pseudo_solid_collapsible_tube subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(pseudo_solid_collapsible_tube C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/pseudo_solid_fsi_channel_with_leaflet/CMakeLists.txt
+++ b/demo_drivers/interaction/pseudo_solid_fsi_channel_with_leaflet/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered pseudo_solid_fsi_channel_with_leaflet subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(pseudo_solid_fsi_channel_with_leaflet C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/turek_flag/CMakeLists.txt
+++ b/demo_drivers/interaction/turek_flag/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered turek_flag subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(turek_flag C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/unsteady_vmtk_fsi/CMakeLists.txt
+++ b/demo_drivers/interaction/unsteady_vmtk_fsi/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unsteady_vmtk_fsi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unsteady_vmtk_fsi C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/unstructured_adaptive_fsi/CMakeLists.txt
+++ b/demo_drivers/interaction/unstructured_adaptive_fsi/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_adaptive_fsi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_adaptive_fsi C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/unstructured_fsi/CMakeLists.txt
+++ b/demo_drivers/interaction/unstructured_fsi/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_fsi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_fsi C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/unstructured_three_d_fsi/CMakeLists.txt
+++ b/demo_drivers/interaction/unstructured_three_d_fsi/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_three_d_fsi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_three_d_fsi C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/interaction/vmtk_fsi/CMakeLists.txt
+++ b/demo_drivers/interaction/vmtk_fsi/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered vmtk_fsi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(vmtk_fsi C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/linear_elasticity/CMakeLists.txt
+++ b/demo_drivers/linear_elasticity/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered linear_elasticity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(linear_elasticity C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/linear_elasticity/periodic_load/CMakeLists.txt
+++ b/demo_drivers/linear_elasticity/periodic_load/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered periodic_load subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(periodic_load C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/linear_solvers/CMakeLists.txt
+++ b/demo_drivers/linear_solvers/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered linear_solvers subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(linear_solvers C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/linear_wave/CMakeLists.txt
+++ b/demo_drivers/linear_wave/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered linear_wave subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(linear_wave C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/linear_wave/two_d_linear_wave/CMakeLists.txt
+++ b/demo_drivers/linear_wave/two_d_linear_wave/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_linear_wave subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_linear_wave C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/linear_wave/two_d_linear_wave_adapt/CMakeLists.txt
+++ b/demo_drivers/linear_wave/two_d_linear_wave_adapt/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_linear_wave_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_linear_wave_adapt C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/linearised_axisym_navier_stokes/CMakeLists.txt
+++ b/demo_drivers/linearised_axisym_navier_stokes/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered linearised_axisym_navier_stokes subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(linearised_axisym_navier_stokes C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/linearised_axisym_navier_stokes/counter_rotating_disks/CMakeLists.txt
+++ b/demo_drivers/linearised_axisym_navier_stokes/counter_rotating_disks/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered counter_rotating_disks subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(counter_rotating_disks C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/linearised_axisym_navier_stokes/time_periodic_taylor_couette/CMakeLists.txt
+++ b/demo_drivers/linearised_axisym_navier_stokes/time_periodic_taylor_couette/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered time_periodic_taylor_couette subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(time_periodic_taylor_couette C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/linearised_free_surface_axisym_navier_stokes/CMakeLists.txt
+++ b/demo_drivers/linearised_free_surface_axisym_navier_stokes/CMakeLists.txt
@@ -12,7 +12,7 @@ list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE
         "Entered linearised_free_surface_axisym_navier_stokes subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(linearised_free_surface_axisym_navier_stokes C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/CMakeLists.txt
+++ b/demo_drivers/linearised_free_surface_axisym_navier_stokes/two_layer_interface_nonaxisym_perturbations/CMakeLists.txt
@@ -12,7 +12,7 @@ list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE
         "Entered two_layer_interface_nonaxisym_perturbations subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_layer_interface_nonaxisym_perturbations C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/meshing/CMakeLists.txt
+++ b/demo_drivers/meshing/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered meshing subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(meshing C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/meshing/adaptive_tet_meshes/CMakeLists.txt
+++ b/demo_drivers/meshing/adaptive_tet_meshes/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered adaptive_tet_meshes subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(adaptive_tet_meshes C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/meshing/mesh_from_geompack/CMakeLists.txt
+++ b/demo_drivers/meshing/mesh_from_geompack/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered mesh_from_geompack subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(mesh_from_geompack C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/meshing/mesh_from_inline_triangle/CMakeLists.txt
+++ b/demo_drivers/meshing/mesh_from_inline_triangle/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered mesh_from_inline_triangle subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(mesh_from_inline_triangle C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/meshing/mesh_from_inline_triangle_internal_boundaries/CMakeLists.txt
+++ b/demo_drivers/meshing/mesh_from_inline_triangle_internal_boundaries/CMakeLists.txt
@@ -12,7 +12,7 @@ list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE
         "Entered mesh_from_inline_triangle_internal_boundaries subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(mesh_from_inline_triangle_internal_boundaries C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/meshing/mesh_from_tetgen/CMakeLists.txt
+++ b/demo_drivers/meshing/mesh_from_tetgen/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered mesh_from_tetgen subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(mesh_from_tetgen C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/meshing/mesh_from_triangle/CMakeLists.txt
+++ b/demo_drivers/meshing/mesh_from_triangle/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered mesh_from_triangle subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(mesh_from_triangle C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/meshing/mesh_from_vmtk/CMakeLists.txt
+++ b/demo_drivers/meshing/mesh_from_vmtk/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered mesh_from_vmtk subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(mesh_from_vmtk C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/meshing/mesh_from_xfig_triangle/CMakeLists.txt
+++ b/demo_drivers/meshing/mesh_from_xfig_triangle/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered mesh_from_xfig_triangle subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(mesh_from_xfig_triangle C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/meshing/quad_from_triangle_mesh/CMakeLists.txt
+++ b/demo_drivers/meshing/quad_from_triangle_mesh/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered quad_from_triangle_mesh subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(quad_from_triangle_mesh C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/meshing/quadratic_vmtk_tetgen/CMakeLists.txt
+++ b/demo_drivers/meshing/quadratic_vmtk_tetgen/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered quadratic_vmtk_tetgen subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(quadratic_vmtk_tetgen C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/CMakeLists.txt
+++ b/demo_drivers/mpi/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered mpi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(mpi C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered distribution subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(distribution C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/adaptive_driven_cavity/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/adaptive_driven_cavity/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered adaptive_driven_cavity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(adaptive_driven_cavity C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/airy_cantilever/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/airy_cantilever/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered airy_cantilever subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(airy_cantilever C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/bifurcation_tracking/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/bifurcation_tracking/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered bifurcation_tracking subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(bifurcation_tracking C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/circular_driven_cavity/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/circular_driven_cavity/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered circular_driven_cavity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(circular_driven_cavity C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/clamped_shell/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/clamped_shell/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered clamped_shell subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(clamped_shell C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/eigenproblem/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/eigenproblem/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered eigenproblem subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(eigenproblem C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/fish_poisson/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/fish_poisson/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fish_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fish_poisson C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/hanging_node_reconciliation/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/hanging_node_reconciliation/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered hanging_node_reconciliation subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(hanging_node_reconciliation C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/hp_adaptive_driven_cavity/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/hp_adaptive_driven_cavity/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered hp_adaptive_driven_cavity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(hp_adaptive_driven_cavity C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/hp_adaptive_poisson/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/hp_adaptive_poisson/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered hp_adaptive_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(hp_adaptive_poisson C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/prescribed_displ_lagr_mult/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/prescribed_displ_lagr_mult/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered prescribed_displ_lagr_mult subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(prescribed_displ_lagr_mult C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/restart/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/restart/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered restart subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(restart C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/three_d_cantilever/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/three_d_cantilever/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered three_d_cantilever subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(three_d_cantilever C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/three_d_entry_flow/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/three_d_entry_flow/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered three_d_entry_flow subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(three_d_entry_flow C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/three_d_prescribed_displ_lagr_mult/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/three_d_prescribed_displ_lagr_mult/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered three_d_prescribed_displ_lagr_mult subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(three_d_prescribed_displ_lagr_mult C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/two_d_poisson_flux_bc_adapt/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/two_d_poisson_flux_bc_adapt/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_poisson_flux_bc_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_poisson_flux_bc_adapt C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/distribution/two_d_unstructured_adaptive_poisson/CMakeLists.txt
+++ b/demo_drivers/mpi/distribution/two_d_unstructured_adaptive_poisson/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_unstructured_adaptive_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_unstructured_adaptive_poisson C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/multi_domain/CMakeLists.txt
+++ b/demo_drivers/mpi/multi_domain/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered multi_domain subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(multi_domain C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/multi_domain/boussinesq_convection/CMakeLists.txt
+++ b/demo_drivers/mpi/multi_domain/boussinesq_convection/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered boussinesq_convection subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(boussinesq_convection C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/multi_domain/fsi_channel_with_leaflet/CMakeLists.txt
+++ b/demo_drivers/mpi/multi_domain/fsi_channel_with_leaflet/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fsi_channel_with_leaflet subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fsi_channel_with_leaflet C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/multi_domain/fsi_collapsible_channel/CMakeLists.txt
+++ b/demo_drivers/mpi/multi_domain/fsi_collapsible_channel/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fsi_collapsible_channel subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fsi_collapsible_channel C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/multi_domain/fsi_osc_ring/CMakeLists.txt
+++ b/demo_drivers/mpi/multi_domain/fsi_osc_ring/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fsi_osc_ring subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fsi_osc_ring C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/multi_domain/pseudo_solid_collapsible_tube/CMakeLists.txt
+++ b/demo_drivers/mpi/multi_domain/pseudo_solid_collapsible_tube/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered pseudo_solid_collapsible_tube subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(pseudo_solid_collapsible_tube C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/multi_domain/turek_flag/CMakeLists.txt
+++ b/demo_drivers/mpi/multi_domain/turek_flag/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered turek_flag subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(turek_flag C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/mpi/solvers/CMakeLists.txt
+++ b/demo_drivers/mpi/solvers/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered solvers subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(solvers C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/multi_physics/3d_boussinesq_convection/CMakeLists.txt
+++ b/demo_drivers/multi_physics/3d_boussinesq_convection/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered 3d_boussinesq_convection subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(3d_boussinesq_convection C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/multi_physics/CMakeLists.txt
+++ b/demo_drivers/multi_physics/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered multi_physics subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(multi_physics C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/multi_physics/axisym_heat_sphere/CMakeLists.txt
+++ b/demo_drivers/multi_physics/axisym_heat_sphere/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered axisym_heat_sphere subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(axisym_heat_sphere C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/multi_physics/b_convection_sphere/CMakeLists.txt
+++ b/demo_drivers/multi_physics/b_convection_sphere/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered b_convection_sphere subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(b_convection_sphere C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/multi_physics/boussinesq_convection/CMakeLists.txt
+++ b/demo_drivers/multi_physics/boussinesq_convection/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered boussinesq_convection subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(boussinesq_convection C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/multi_physics/double_diffusive_convection/CMakeLists.txt
+++ b/demo_drivers/multi_physics/double_diffusive_convection/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered double_diffusive_convection subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(double_diffusive_convection C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/multi_physics/insoluble_surfactant/CMakeLists.txt
+++ b/demo_drivers/multi_physics/insoluble_surfactant/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered insoluble_surfactant subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(insoluble_surfactant C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/multi_physics/marangoni_convection/CMakeLists.txt
+++ b/demo_drivers/multi_physics/marangoni_convection/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered marangoni_convection subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(marangoni_convection C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/multi_physics/rayleigh_instability_surfactant/CMakeLists.txt
+++ b/demo_drivers/multi_physics/rayleigh_instability_surfactant/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered rayleigh_instability_surfactant subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(rayleigh_instability_surfactant C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/multi_physics/soluble_surfactant/CMakeLists.txt
+++ b/demo_drivers/multi_physics/soluble_surfactant/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered soluble_surfactant subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(soluble_surfactant C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/multi_physics/spherical_shell_convection/CMakeLists.txt
+++ b/demo_drivers/multi_physics/spherical_shell_convection/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered spherical_shell_convection subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(spherical_shell_convection C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/multi_physics/thermal_fibre/CMakeLists.txt
+++ b/demo_drivers/multi_physics/thermal_fibre/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered thermal_fibre subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(thermal_fibre C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/multi_physics/thermo/CMakeLists.txt
+++ b/demo_drivers/multi_physics/thermo/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered thermo subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(thermo C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/multi_physics/two_layer_soluble_surfactant/CMakeLists.txt
+++ b/demo_drivers/multi_physics/two_layer_soluble_surfactant/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_layer_soluble_surfactant subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_layer_soluble_surfactant C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/multigrid/CMakeLists.txt
+++ b/demo_drivers/multigrid/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered multigrid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(multigrid C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/multigrid/helmholtz_multigrid/CMakeLists.txt
+++ b/demo_drivers/multigrid/helmholtz_multigrid/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered helmholtz_multigrid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(helmholtz_multigrid C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/multigrid/scalar_multigrid/CMakeLists.txt
+++ b/demo_drivers/multigrid/scalar_multigrid/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered scalar_multigrid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(scalar_multigrid C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered navier_stokes subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(navier_stokes C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/adaptive_driven_cavity/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/adaptive_driven_cavity/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered adaptive_driven_cavity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(adaptive_driven_cavity C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/adaptive_interface/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/adaptive_interface/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered adaptive_interface subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(adaptive_interface C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/bretherton/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/bretherton/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered bretherton subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(bretherton C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/channel_with_leaflet/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/channel_with_leaflet/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered channel_with_leaflet subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(channel_with_leaflet C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/circular_driven_cavity/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/circular_driven_cavity/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered circular_driven_cavity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(circular_driven_cavity C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/collapsible_channel/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/collapsible_channel/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered collapsible_channel subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(collapsible_channel C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/curved_pipe/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/curved_pipe/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered curved_pipe subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(curved_pipe C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/driven_cavity/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/driven_cavity/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered driven_cavity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(driven_cavity C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/falling_jet/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/falling_jet/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered falling_jet subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(falling_jet C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/flow_past_cylinder/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/flow_past_cylinder/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered flow_past_cylinder subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(flow_past_cylinder C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/flow_past_oscillating_cylinder/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/flow_past_oscillating_cylinder/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered flow_past_oscillating_cylinder subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(flow_past_oscillating_cylinder C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/flux_control/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/flux_control/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered flux_control subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(flux_control C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/free_surface_rotation/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/free_surface_rotation/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered free_surface_rotation subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(free_surface_rotation C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/hp_adaptive_driven_cavity/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/hp_adaptive_driven_cavity/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered hp_adaptive_driven_cavity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(hp_adaptive_driven_cavity C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/inclined_plane/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/inclined_plane/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered inclined_plane subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(inclined_plane C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/jeffery_orbit/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/jeffery_orbit/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered jeffery_orbit subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(jeffery_orbit C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/lagrange_enforced_flow_preconditioner/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/lagrange_enforced_flow_preconditioner/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered lagrange_enforced_flow_preconditioner subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(lagrange_enforced_flow_preconditioner C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/navier_stokes_with_singularity/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/navier_stokes_with_singularity/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered navier_stokes_with_singularity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(navier_stokes_with_singularity C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/osc_ellipse/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/osc_ellipse/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered osc_ellipse subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(osc_ellipse C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/osc_ring/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/osc_ring/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered osc_ring subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(osc_ring C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/rayleigh_channel/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/rayleigh_channel/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered rayleigh_channel subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(rayleigh_channel C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/rayleigh_traction_channel/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/rayleigh_traction_channel/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered rayleigh_traction_channel subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(rayleigh_traction_channel C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/schur_complement_preconditioner/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/schur_complement_preconditioner/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered schur_complement_preconditioner subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(schur_complement_preconditioner C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/single_layer_free_surface/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/single_layer_free_surface/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered single_layer_free_surface subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(single_layer_free_surface C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/space_time_flow_past_oscillating_cylinder/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/space_time_flow_past_oscillating_cylinder/CMakeLists.txt
@@ -12,7 +12,7 @@ list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE
         "Entered space_time_flow_past_oscillating_cylinder subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(space_time_oscillating_cylinder C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/spine_channel/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/spine_channel/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered spine_channel subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(spine_channel C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/static_cap/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/static_cap/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered static_cap subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(static_cap C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/three_d_bretherton/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/three_d_bretherton/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered three_d_bretherton subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(three_d_bretherton C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/three_d_entry_flow/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/three_d_entry_flow/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered three_d_entry_flow subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(three_d_entry_flow C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/three_d_free_surface/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/three_d_free_surface/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered three_d_free_surface subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(three_d_free_surface C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/three_d_static_cap/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/three_d_static_cap/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered three_d_static_cap subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(three_d_static_cap C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/turek_flag_non_fsi/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/turek_flag_non_fsi/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered turek_flag_non_fsi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(turek_flag_non_fsi C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/two_layer_interface/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/two_layer_interface/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_layer_interface subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_layer_interface C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/unstructured_adaptive_3d_ALE/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/unstructured_adaptive_3d_ALE/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_adaptive_3d_ALE subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_adaptive_3d_ALE C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/unstructured_adaptive_ALE/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/unstructured_adaptive_ALE/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_adaptive_ALE subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_adaptive_ALE C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/unstructured_adaptive_fs/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/unstructured_adaptive_fs/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_adaptive_fs subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_adaptive_fs C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/unstructured_fluid/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/unstructured_fluid/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_fluid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_fluid C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/unstructured_three_d_fluid/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/unstructured_three_d_fluid/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_three_d_fluid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_three_d_fluid C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/vmtk_fluid/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/vmtk_fluid/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered vmtk_fluid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(vmtk_fluid C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/navier_stokes/vorticity_smoother/CMakeLists.txt
+++ b/demo_drivers/navier_stokes/vorticity_smoother/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered vorticity_smoother subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(vorticity_smoother C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/ode/CMakeLists.txt
+++ b/demo_drivers/ode/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered ode subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(ode C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/ode/basic_ode/CMakeLists.txt
+++ b/demo_drivers/ode/basic_ode/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered basic_ode subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(basic_ode C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/optimisation/CMakeLists.txt
+++ b/demo_drivers/optimisation/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered optimisation subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(optimisation C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/optimisation/C_style_output/CMakeLists.txt
+++ b/demo_drivers/optimisation/C_style_output/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered C_style_output subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(C_style_output C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/optimisation/disable_ALE/CMakeLists.txt
+++ b/demo_drivers/optimisation/disable_ALE/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered disable_ALE subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(disable_ALE C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/optimisation/disable_ALE/navier_stokes/CMakeLists.txt
+++ b/demo_drivers/optimisation/disable_ALE/navier_stokes/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered navier_stokes subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(navier_stokes C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/optimisation/disable_ALE/unsteady_heat/CMakeLists.txt
+++ b/demo_drivers/optimisation/disable_ALE/unsteady_heat/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unsteady_heat subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unsteady_heat C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/optimisation/fsi_jacobian_approximation/CMakeLists.txt
+++ b/demo_drivers/optimisation/fsi_jacobian_approximation/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fsi_jacobian_approximation subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fsi_jacobian_approximation C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/optimisation/linear_vs_nonlinear/CMakeLists.txt
+++ b/demo_drivers/optimisation/linear_vs_nonlinear/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered linear_vs_nonlinear subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(linear_vs_nonlinear C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/optimisation/sparse_assemble/CMakeLists.txt
+++ b/demo_drivers/optimisation/sparse_assemble/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered sparse_assemble subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(sparse_assemble C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/optimisation/stored_shape_fcts/CMakeLists.txt
+++ b/demo_drivers/optimisation/stored_shape_fcts/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered stored_shape_fcts subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(stored_shape_fcts C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/optimisation/use_coarse_base_meshes/CMakeLists.txt
+++ b/demo_drivers/optimisation/use_coarse_base_meshes/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered use_coarse_base_meshes subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(use_coarse_base_meshes C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/pml_fourier_decomposed_helmholtz/CMakeLists.txt
+++ b/demo_drivers/pml_fourier_decomposed_helmholtz/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered pml_fourier_decomposed_helmholtz subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(pml_fourier_decomposed_helmholtz C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/pml_fourier_decomposed_helmholtz/oscillating_sphere/CMakeLists.txt
+++ b/demo_drivers/pml_fourier_decomposed_helmholtz/oscillating_sphere/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered oscillating_sphere subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(oscillating_sphere C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/pml_helmholtz/CMakeLists.txt
+++ b/demo_drivers/pml_helmholtz/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered pml_helmholtz subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(pml_helmholtz C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/pml_helmholtz/scattering/CMakeLists.txt
+++ b/demo_drivers/pml_helmholtz/scattering/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered scattering subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(scattering C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/pml_time_harmonic_linear_elasticity/CMakeLists.txt
+++ b/demo_drivers/pml_time_harmonic_linear_elasticity/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered pml_time_harmonic_linear_elasticity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(pml_time_harmonic_linear_elasticity C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/CMakeLists.txt
+++ b/demo_drivers/poisson/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(poisson C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/eighth_sphere_poisson/CMakeLists.txt
+++ b/demo_drivers/poisson/eighth_sphere_poisson/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered eighth_sphere_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(eighth_sphere_poisson C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/eighth_sphere_poisson_hp_adapt/CMakeLists.txt
+++ b/demo_drivers/poisson/eighth_sphere_poisson_hp_adapt/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered eighth_sphere_poisson_hp_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(eighth_sphere_poisson_hp_adapt C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/elastic_poisson/CMakeLists.txt
+++ b/demo_drivers/poisson/elastic_poisson/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered elastic_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(elastic_poisson C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/fish_poisson/CMakeLists.txt
+++ b/demo_drivers/poisson/fish_poisson/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fish_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fish_poisson C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/fish_poisson2/CMakeLists.txt
+++ b/demo_drivers/poisson/fish_poisson2/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fish_poisson2 subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fish_poisson2 C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/one_d_poisson/CMakeLists.txt
+++ b/demo_drivers/poisson/one_d_poisson/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered one_d_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(one_d_poisson C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/one_d_poisson_adapt/CMakeLists.txt
+++ b/demo_drivers/poisson/one_d_poisson_adapt/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered one_d_poisson_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(one_d_poisson_adapt C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/one_d_poisson_generic_only/CMakeLists.txt
+++ b/demo_drivers/poisson/one_d_poisson_generic_only/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered one_d_poisson_generic_only subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(one_d_poisson_generic_only C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/one_d_poisson_hp_adapt/CMakeLists.txt
+++ b/demo_drivers/poisson/one_d_poisson_hp_adapt/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered one_d_poisson_hp_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(one_d_poisson_hp_adapt C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/poisson_with_singularity/CMakeLists.txt
+++ b/demo_drivers/poisson/poisson_with_singularity/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered poisson_with_singularity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(poisson_with_singularity C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/spectral/CMakeLists.txt
+++ b/demo_drivers/poisson/spectral/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered spectral subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(spectral C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/two_d_poisson/CMakeLists.txt
+++ b/demo_drivers/poisson/two_d_poisson/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_poisson C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/two_d_poisson_adapt/CMakeLists.txt
+++ b/demo_drivers/poisson/two_d_poisson_adapt/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_poisson_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_poisson_adapt C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/two_d_poisson_flux_bc/CMakeLists.txt
+++ b/demo_drivers/poisson/two_d_poisson_flux_bc/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_poisson_flux_bc subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_poisson_flux_bc C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/two_d_poisson_flux_bc2/CMakeLists.txt
+++ b/demo_drivers/poisson/two_d_poisson_flux_bc2/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_poisson_flux_bc2 subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_poisson_flux_bc2 C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/two_d_poisson_flux_bc_adapt/CMakeLists.txt
+++ b/demo_drivers/poisson/two_d_poisson_flux_bc_adapt/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_poisson_flux_bc_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_poisson_flux_bc_adapt C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/poisson/two_d_poisson_hp_adapt/CMakeLists.txt
+++ b/demo_drivers/poisson/two_d_poisson_hp_adapt/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_poisson_hp_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_poisson_hp_adapt C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/polar_navier_stokes/CMakeLists.txt
+++ b/demo_drivers/polar_navier_stokes/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered polar_navier_stokes subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(polar_navier_stokes C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/polar_navier_stokes/jeffery_hamel/CMakeLists.txt
+++ b/demo_drivers/polar_navier_stokes/jeffery_hamel/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered jeffery_hamel subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(jeffery_hamel C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/reaction_diffusion/CMakeLists.txt
+++ b/demo_drivers/reaction_diffusion/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered reaction_diffusion subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(reaction_diffusion C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/reaction_diffusion/one_d_act_inhibit/CMakeLists.txt
+++ b/demo_drivers/reaction_diffusion/one_d_act_inhibit/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered one_d_act_inhibit subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(one_d_act_inhibit C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/reaction_diffusion/two_d_act_inhibit/CMakeLists.txt
+++ b/demo_drivers/reaction_diffusion/two_d_act_inhibit/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_act_inhibit subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_act_inhibit C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/reaction_diffusion/two_d_act_inhibit_adapt/CMakeLists.txt
+++ b/demo_drivers/reaction_diffusion/two_d_act_inhibit_adapt/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_act_inhibit_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_act_inhibit_adapt C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/reaction_diffusion/unstructured_two_d_act_inhibit/CMakeLists.txt
+++ b/demo_drivers/reaction_diffusion/unstructured_two_d_act_inhibit/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_two_d_act_inhibit subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_two_d_act_inhibit C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/CMakeLists.txt
+++ b/demo_drivers/self_test/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered self_test subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(self_test C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/deliberately_broken_code_for_self_test_test/CMakeLists.txt
+++ b/demo_drivers/self_test/deliberately_broken_code_for_self_test_test/CMakeLists.txt
@@ -12,7 +12,7 @@ list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE
         "Entered deliberately_broken_code_for_self_test_test subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(deliberately_broken_code_for_self_test_test C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/faceted_surface_vtu_output/CMakeLists.txt
+++ b/demo_drivers/self_test/faceted_surface_vtu_output/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered faceted_surface_vtu_output subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(faceted_surface_vtu_output C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/generic/CMakeLists.txt
+++ b/demo_drivers/self_test/generic/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered generic subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(generic C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/generic/block_selector_test/CMakeLists.txt
+++ b/demo_drivers/self_test/generic/block_selector_test/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered block_selector_test subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(block_selector_test C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/generic/complex_matrices_test/CMakeLists.txt
+++ b/demo_drivers/self_test/generic/complex_matrices_test/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered complex_matrices_test subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(complex_matrices_test C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/generic/eigen_solver_test/CMakeLists.txt
+++ b/demo_drivers/self_test/generic/eigen_solver_test/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered eigen_solver_test subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(eigen_solver_test C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/generic/problem_test/CMakeLists.txt
+++ b/demo_drivers/self_test/generic/problem_test/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered problem_test subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(problem_test C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/generic/vector_matrix_test/CMakeLists.txt
+++ b/demo_drivers/self_test/generic/vector_matrix_test/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered vector_matrix_test subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(vector_matrix_test C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/line_visualiser/CMakeLists.txt
+++ b/demo_drivers/self_test/line_visualiser/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered line_visualiser subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(line_visualiser C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/locate_zeta/CMakeLists.txt
+++ b/demo_drivers/self_test/locate_zeta/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered locate_zeta subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(locate_zeta C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/matrix_matrix_multiply/CMakeLists.txt
+++ b/demo_drivers/self_test/matrix_matrix_multiply/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered matrix_matrix_multiply subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(matrix_matrix_multiply C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/mpi/CMakeLists.txt
+++ b/demo_drivers/self_test/mpi/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered mpi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(mpi C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/mpi/crdoublematrix_copy_constructor/CMakeLists.txt
+++ b/demo_drivers/self_test/mpi/crdoublematrix_copy_constructor/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered crdoublematrix_copy_constructor subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(crdoublematrix_copy_constructor C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/mpi/distribution_concatenation/CMakeLists.txt
+++ b/demo_drivers/self_test/mpi/distribution_concatenation/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered distribution_concatenation subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(distribution_concatenation C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/mpi/eigen_solver/CMakeLists.txt
+++ b/demo_drivers/self_test/mpi/eigen_solver/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered eigen_solver subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(eigen_solver C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/mpi/generic_mpi/CMakeLists.txt
+++ b/demo_drivers/self_test/mpi/generic_mpi/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered generic_mpi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(generic_mpi C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/mpi/line_visualiser/CMakeLists.txt
+++ b/demo_drivers/self_test/mpi/line_visualiser/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered line_visualiser subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(line_visualiser C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/mpi/matrix_addition/CMakeLists.txt
+++ b/demo_drivers/self_test/mpi/matrix_addition/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered matrix_addition subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(matrix_addition C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/mpi/matrix_concatenation/CMakeLists.txt
+++ b/demo_drivers/self_test/mpi/matrix_concatenation/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered matrix_concatenation subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(matrix_concatenation C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/mpi/matrix_concatenation_without_communication/CMakeLists.txt
+++ b/demo_drivers/self_test/mpi/matrix_concatenation_without_communication/CMakeLists.txt
@@ -12,7 +12,7 @@ list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE
         "Entered matrix_concatenation_without_communication subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(matrix_concatenation_without_communication C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/mpi/metis_based_partition_tester/CMakeLists.txt
+++ b/demo_drivers/self_test/mpi/metis_based_partition_tester/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered metis_based_partition_tester subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(metis_based_partition_tester C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/mpi/three_d_mesh_dist/CMakeLists.txt
+++ b/demo_drivers/self_test/mpi/three_d_mesh_dist/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered three_d_mesh_dist subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(three_d_mesh_dist C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/mpi/two_d_mesh_dist/CMakeLists.txt
+++ b/demo_drivers/self_test/mpi/two_d_mesh_dist/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_mesh_dist subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_mesh_dist C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/mpi/vector_concatenation/CMakeLists.txt
+++ b/demo_drivers/self_test/mpi/vector_concatenation/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered vector_concatenation subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(vector_concatenation C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/mpi/vector_concatenation_without_communication/CMakeLists.txt
+++ b/demo_drivers/self_test/mpi/vector_concatenation_without_communication/CMakeLists.txt
@@ -12,7 +12,7 @@ list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE
         "Entered vector_concatenation_without_communication subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(vector_concatenation_without_communication C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/mpi/vector_split/CMakeLists.txt
+++ b/demo_drivers/self_test/mpi/vector_split/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered vector_split subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(vector_split C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/mpi/vector_split_without_communication/CMakeLists.txt
+++ b/demo_drivers/self_test/mpi/vector_split_without_communication/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered vector_split_without_communication subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(vector_split_without_communication C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/navier_stokes/CMakeLists.txt
+++ b/demo_drivers/self_test/navier_stokes/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered navier_stokes subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(navier_stokes C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/poisson/CMakeLists.txt
+++ b/demo_drivers/self_test/poisson/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(poisson C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/poisson/convergence_tests/CMakeLists.txt
+++ b/demo_drivers/self_test/poisson/convergence_tests/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered convergence_tests subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(convergence_tests C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/poisson/face_tests/CMakeLists.txt
+++ b/demo_drivers/self_test/poisson/face_tests/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered face_tests subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(face_tests C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/poisson/octree_test/CMakeLists.txt
+++ b/demo_drivers/self_test/poisson/octree_test/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered octree_test subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(octree_test C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/self_test/poisson/tree_rotation_tests/CMakeLists.txt
+++ b/demo_drivers/self_test/poisson/tree_rotation_tests/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered tree_rotation_tests subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(tree_rotation_tests C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/shell/CMakeLists.txt
+++ b/demo_drivers/shell/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered shell subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(shell C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/shell/clamped_or_pinned_shell/CMakeLists.txt
+++ b/demo_drivers/shell/clamped_or_pinned_shell/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered clamped_or_pinned_shell subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(clamped_or_pinned_shell C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/shell/clamped_shell/CMakeLists.txt
+++ b/demo_drivers/shell/clamped_shell/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered clamped_shell subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(clamped_shell C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/shell/oscillating_shell/CMakeLists.txt
+++ b/demo_drivers/shell/oscillating_shell/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered oscillating_shell subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(oscillating_shell C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/shell/plate/CMakeLists.txt
+++ b/demo_drivers/shell/plate/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered plate subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(plate C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/solid/CMakeLists.txt
+++ b/demo_drivers/solid/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered solid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(solid C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/solid/airy_cantilever/CMakeLists.txt
+++ b/demo_drivers/solid/airy_cantilever/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered airy_cantilever subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(airy_cantilever C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/solid/compressed_square/CMakeLists.txt
+++ b/demo_drivers/solid/compressed_square/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered compressed_square subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(compressed_square C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/solid/disk_compression/CMakeLists.txt
+++ b/demo_drivers/solid/disk_compression/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered disk_compression subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(disk_compression C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/solid/disk_oscillation/CMakeLists.txt
+++ b/demo_drivers/solid/disk_oscillation/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered disk_oscillation subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(disk_oscillation C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/solid/prescribed_displ_lagr_mult/CMakeLists.txt
+++ b/demo_drivers/solid/prescribed_displ_lagr_mult/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered prescribed_displ_lagr_mult subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(prescribed_displ_lagr_mult C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/solid/pseudo_solid_collapsible_channel/CMakeLists.txt
+++ b/demo_drivers/solid/pseudo_solid_collapsible_channel/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered pseudo_solid_collapsible_channel subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(pseudo_solid_collapsible_channel C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/solid/shock_disk/CMakeLists.txt
+++ b/demo_drivers/solid/shock_disk/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered shock_disk subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(shock_disk C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/solid/simple_shear/CMakeLists.txt
+++ b/demo_drivers/solid/simple_shear/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered simple_shear subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(simple_shear C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/solid/static_fish/CMakeLists.txt
+++ b/demo_drivers/solid/static_fish/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered static_fish subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(static_fish C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/solid/three_d_cantilever/CMakeLists.txt
+++ b/demo_drivers/solid/three_d_cantilever/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered three_d_cantilever subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(three_d_cantilever C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/solid/three_d_prescribed_displ_lagr_mult/CMakeLists.txt
+++ b/demo_drivers/solid/three_d_prescribed_displ_lagr_mult/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered three_d_prescribed_displ_lagr_mult subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(three_d_prescribed_displ_lagr_mult C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/solid/three_d_traction/CMakeLists.txt
+++ b/demo_drivers/solid/three_d_traction/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered three_d_traction subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(three_d_traction C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/solid/unstructured_adaptive_solid/CMakeLists.txt
+++ b/demo_drivers/solid/unstructured_adaptive_solid/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_adaptive_solid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_adaptive_solid C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/solid/unstructured_solid/CMakeLists.txt
+++ b/demo_drivers/solid/unstructured_solid/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_solid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_solid C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/solid/unstructured_three_d_solid/CMakeLists.txt
+++ b/demo_drivers/solid/unstructured_three_d_solid/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_three_d_solid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_three_d_solid C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/solid/vmtk_solid/CMakeLists.txt
+++ b/demo_drivers/solid/vmtk_solid/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered vmtk_solid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(vmtk_solid C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/spherical_advection_diffusion/CMakeLists.txt
+++ b/demo_drivers/spherical_advection_diffusion/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered spherical_advection_diffusion subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(spherical_advection_diffusion C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/spherical_advection_diffusion/eluting_sphere/CMakeLists.txt
+++ b/demo_drivers/spherical_advection_diffusion/eluting_sphere/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered eluting_sphere subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(eluting_sphere C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/spherical_navier_stokes/CMakeLists.txt
+++ b/demo_drivers/spherical_navier_stokes/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered spherical_navier_stokes subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(spherical_navier_stokes C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/spherical_navier_stokes/spherical_couette/CMakeLists.txt
+++ b/demo_drivers/spherical_navier_stokes/spherical_couette/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered spherical_couette subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(spherical_couette C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/spherical_navier_stokes/spin_up/CMakeLists.txt
+++ b/demo_drivers/spherical_navier_stokes/spin_up/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered spin_up subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(spin_up C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/spherical_navier_stokes/steady_rot/CMakeLists.txt
+++ b/demo_drivers/spherical_navier_stokes/steady_rot/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered steady_rot subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(steady_rot C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/steady_axisym_advection_diffusion/CMakeLists.txt
+++ b/demo_drivers/steady_axisym_advection_diffusion/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered steady_axisym_advection_diffusion subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(steady_axisym_advection_diffusion C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/steady_axisym_advection_diffusion/steady_axisym_advection_diffusion/CMakeLists.txt
+++ b/demo_drivers/steady_axisym_advection_diffusion/steady_axisym_advection_diffusion/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered steady_axisym_advection_diffusion subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(steady_axisym_advection_diffusion C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/time_harmonic_fourier_decomposed_linear_elasticity/CMakeLists.txt
+++ b/demo_drivers/time_harmonic_fourier_decomposed_linear_elasticity/CMakeLists.txt
@@ -13,7 +13,7 @@ message(
   VERBOSE
   "Entered time_harmonic_fourier_decomposed_linear_elasticity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(time_harmonic_fourier_decomposed_linear_elasticity C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/time_harmonic_fourier_decomposed_linear_elasticity/cylinder/CMakeLists.txt
+++ b/demo_drivers/time_harmonic_fourier_decomposed_linear_elasticity/cylinder/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered cylinder subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(cylinder C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/time_harmonic_linear_elasticity/CMakeLists.txt
+++ b/demo_drivers/time_harmonic_linear_elasticity/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered time_harmonic_linear_elasticity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(time_harmonic_linear_elasticity C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/time_harmonic_linear_elasticity/elastic_annulus/CMakeLists.txt
+++ b/demo_drivers/time_harmonic_linear_elasticity/elastic_annulus/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered elastic_annulus subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(elastic_annulus C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/unsteady_heat/CMakeLists.txt
+++ b/demo_drivers/unsteady_heat/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unsteady_heat subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unsteady_heat C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/unsteady_heat/space_time_two_d_unsteady_heat/CMakeLists.txt
+++ b/demo_drivers/unsteady_heat/space_time_two_d_unsteady_heat/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered space_time_two_d_unsteady_heat subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(space_time_two_d_unsteady_heat C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/unsteady_heat/two_d_unsteady_heat/CMakeLists.txt
+++ b/demo_drivers/unsteady_heat/two_d_unsteady_heat/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_unsteady_heat subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_unsteady_heat C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/unsteady_heat/two_d_unsteady_heat_2adapt/CMakeLists.txt
+++ b/demo_drivers/unsteady_heat/two_d_unsteady_heat_2adapt/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_unsteady_heat_2adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_unsteady_heat_2adapt C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/unsteady_heat/two_d_unsteady_heat_ALE/CMakeLists.txt
+++ b/demo_drivers/unsteady_heat/two_d_unsteady_heat_ALE/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_unsteady_heat_ALE subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_unsteady_heat_ALE C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/unsteady_heat/two_d_unsteady_heat_adapt/CMakeLists.txt
+++ b/demo_drivers/unsteady_heat/two_d_unsteady_heat_adapt/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_unsteady_heat_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_unsteady_heat_adapt C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/unsteady_heat/two_d_unsteady_heat_t_adapt/CMakeLists.txt
+++ b/demo_drivers/unsteady_heat/two_d_unsteady_heat_t_adapt/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_unsteady_heat_t_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_unsteady_heat_t_adapt C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/womersley/CMakeLists.txt
+++ b/demo_drivers/womersley/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered womersley subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(womersley C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/womersley/one_d_womersley/CMakeLists.txt
+++ b/demo_drivers/womersley/one_d_womersley/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered one_d_womersley subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(one_d_womersley C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/womersley/two_d_womersley/CMakeLists.txt
+++ b/demo_drivers/womersley/two_d_womersley/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_womersley subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_womersley C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/demo_drivers/young_laplace/CMakeLists.txt
+++ b/demo_drivers/young_laplace/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered young_laplace subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(young_laplace C CXX Fortran)
 
 if(NOT oomphlib_FOUND)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -3,7 +3,7 @@ list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered doc subdirectory")
 
 # Project meta & global options
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(doc LANGUAGES C CXX Fortran)
 
 # This doc build is *configure + build* only

--- a/doc/FAQ/CMakeLists.txt
+++ b/doc/FAQ/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered FAQ subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(FAQ C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/acknowledgements/CMakeLists.txt
+++ b/doc/acknowledgements/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered acknowledgements subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(acknowledgements C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/acoustic_fsi/acoustic_fsi_annulus/CMakeLists.txt
+++ b/doc/acoustic_fsi/acoustic_fsi_annulus/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered acoustic_fsi_annulus subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(acoustic_fsi_annulus C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/acoustic_fsi/unstructured_acoustic_fsi_annulus/CMakeLists.txt
+++ b/doc/acoustic_fsi/unstructured_acoustic_fsi_annulus/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_acoustic_fsi_annulus subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_acoustic_fsi_annulus C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/advection_diffusion/two_d_adv_diff_SUPG/CMakeLists.txt
+++ b/doc/advection_diffusion/two_d_adv_diff_SUPG/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_adv_diff_SUPG subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_adv_diff_SUPG C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/advection_diffusion/two_d_adv_diff_adapt/CMakeLists.txt
+++ b/doc/advection_diffusion/two_d_adv_diff_adapt/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_adv_diff_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_adv_diff_adapt C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/advection_diffusion/two_d_adv_diff_flux_bc/CMakeLists.txt
+++ b/doc/advection_diffusion/two_d_adv_diff_flux_bc/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_adv_diff_flux_bc subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_adv_diff_flux_bc C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/axisym_linear_elasticity/cylinder/CMakeLists.txt
+++ b/doc/axisym_linear_elasticity/cylinder/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered cylinder subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(cylinder C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/axisym_navier_stokes/axi_static_cap/CMakeLists.txt
+++ b/doc/axisym_navier_stokes/axi_static_cap/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered axi_static_cap subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(axi_static_cap C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/axisym_navier_stokes/spin_up/CMakeLists.txt
+++ b/doc/axisym_navier_stokes/spin_up/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered spin_up subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(spin_up C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/axisym_navier_stokes/two_layer_interface_axisym/CMakeLists.txt
+++ b/doc/axisym_navier_stokes/two_layer_interface_axisym/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_layer_interface_axisym subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_layer_interface_axisym C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/beam/lin_unsteady_ring/CMakeLists.txt
+++ b/doc/beam/lin_unsteady_ring/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered lin_unsteady_ring subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(lin_unsteady_ring C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/beam/steady_ring/CMakeLists.txt
+++ b/doc/beam/steady_ring/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered steady_ring subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(steady_ring C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/beam/tensioned_string/CMakeLists.txt
+++ b/doc/beam/tensioned_string/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered tensioned_string subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(tensioned_string C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/beam/unsteady_ring/CMakeLists.txt
+++ b/doc/beam/unsteady_ring/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unsteady_ring subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unsteady_ring C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/bugs/CMakeLists.txt
+++ b/doc/bugs/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered bugs subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(bugs C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/change_log/CMakeLists.txt
+++ b/doc/change_log/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered change_log subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(change_log C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/coding_conventions/CMakeLists.txt
+++ b/doc/coding_conventions/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered coding_conventions subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(coding_conventions C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/contact/CMakeLists.txt
+++ b/doc/contact/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered contact subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(contact C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/copyright/CMakeLists.txt
+++ b/doc/copyright/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered copyright subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(copyright C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/creating_doc/CMakeLists.txt
+++ b/doc/creating_doc/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered creating_doc subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(creating_doc C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/deliberately_broken_doc_for_checking/CMakeLists.txt
+++ b/doc/deliberately_broken_doc_for_checking/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered deliberately_broken_doc_for_checking subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(deliberately_broken_doc_for_checking C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/eigenproblems/complex_harmonic/CMakeLists.txt
+++ b/doc/eigenproblems/complex_harmonic/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered complex_harmonic subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(complex_harmonic C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/eigenproblems/harmonic/CMakeLists.txt
+++ b/doc/eigenproblems/harmonic/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered harmonic subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(harmonic C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/example_code_list/CMakeLists.txt
+++ b/doc/example_code_list/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered example_code_list subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(example_code_list C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/fourier_decomposed_acoustic_fsi/sphere/CMakeLists.txt
+++ b/doc/fourier_decomposed_acoustic_fsi/sphere/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered sphere subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(sphere C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/fourier_decomposed_acoustic_fsi/unstructured_sphere/CMakeLists.txt
+++ b/doc/fourier_decomposed_acoustic_fsi/unstructured_sphere/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_sphere subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_sphere C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/fourier_decomposed_helmholtz/adaptive_sphere_scattering/CMakeLists.txt
+++ b/doc/fourier_decomposed_helmholtz/adaptive_sphere_scattering/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered adaptive_sphere_scattering subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(adaptive_sphere_scattering C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/fourier_decomposed_helmholtz/sphere_scattering/CMakeLists.txt
+++ b/doc/fourier_decomposed_helmholtz/sphere_scattering/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered sphere_scattering subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(sphere_scattering C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/helmholtz/scattering/CMakeLists.txt
+++ b/doc/helmholtz/scattering/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered scattering subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(scattering C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/helmholtz/unstructured_scattering/CMakeLists.txt
+++ b/doc/helmholtz/unstructured_scattering/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_scattering subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_scattering C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/hijacking/CMakeLists.txt
+++ b/doc/hijacking/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered hijacking subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(hijacking C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/index/CMakeLists.txt
+++ b/doc/index/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered index subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(index C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../")
 

--- a/doc/interaction/algebraic_free_boundary_poisson/CMakeLists.txt
+++ b/doc/interaction/algebraic_free_boundary_poisson/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered algebraic_free_boundary_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(algebraic_free_boundary_poisson C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/interaction/circle_as_element/CMakeLists.txt
+++ b/doc/interaction/circle_as_element/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered circle_as_element subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(circle_as_element C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/interaction/elastic_poisson/CMakeLists.txt
+++ b/doc/interaction/elastic_poisson/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered elastic_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(elastic_poisson C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/interaction/fsi_channel_segregated_solver/CMakeLists.txt
+++ b/doc/interaction/fsi_channel_segregated_solver/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fsi_channel_segregated_solver subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fsi_channel_segregated_solver C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/interaction/fsi_channel_with_leaflet/CMakeLists.txt
+++ b/doc/interaction/fsi_channel_with_leaflet/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fsi_channel_with_leaflet subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fsi_channel_with_leaflet C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/interaction/fsi_collapsible_channel/CMakeLists.txt
+++ b/doc/interaction/fsi_collapsible_channel/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fsi_collapsible_channel subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fsi_collapsible_channel C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/interaction/fsi_collapsible_channel_adapt/CMakeLists.txt
+++ b/doc/interaction/fsi_collapsible_channel_adapt/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fsi_collapsible_channel_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fsi_collapsible_channel_adapt C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/interaction/fsi_collapsible_channel_algebraic/CMakeLists.txt
+++ b/doc/interaction/fsi_collapsible_channel_algebraic/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fsi_collapsible_channel_algebraic subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fsi_collapsible_channel_algebraic C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/interaction/fsi_osc_ring/CMakeLists.txt
+++ b/doc/interaction/fsi_osc_ring/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fsi_osc_ring subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fsi_osc_ring C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/interaction/macro_element_free_boundary_poisson/CMakeLists.txt
+++ b/doc/interaction/macro_element_free_boundary_poisson/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered macro_element_free_boundary_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(macro_element_free_boundary_poisson C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/interaction/osc_ring_algebraic/CMakeLists.txt
+++ b/doc/interaction/osc_ring_algebraic/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered osc_ring_algebraic subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(osc_ring_algebraic C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/interaction/osc_ring_macro/CMakeLists.txt
+++ b/doc/interaction/osc_ring_macro/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered osc_ring_macro subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(osc_ring_macro C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/interaction/turek_flag/CMakeLists.txt
+++ b/doc/interaction/turek_flag/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered turek_flag subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(turek_flag C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/interaction/unstructured_adaptive_fsi/CMakeLists.txt
+++ b/doc/interaction/unstructured_adaptive_fsi/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_adaptive_fsi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_adaptive_fsi C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/interaction/unstructured_fsi/CMakeLists.txt
+++ b/doc/interaction/unstructured_fsi/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_fsi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_fsi C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/interaction/unstructured_three_d_fsi/CMakeLists.txt
+++ b/doc/interaction/unstructured_three_d_fsi/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_three_d_fsi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_three_d_fsi C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/interaction/vmtk_fsi/CMakeLists.txt
+++ b/doc/interaction/vmtk_fsi/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered vmtk_fsi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(vmtk_fsi C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/intro/CMakeLists.txt
+++ b/doc/intro/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered intro subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(intro C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/leftovers/CMakeLists.txt
+++ b/doc/leftovers/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered leftovers subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(leftovers C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/linear_elasticity/periodic_load/CMakeLists.txt
+++ b/doc/linear_elasticity/periodic_load/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered periodic_load subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(periodic_load C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/linear_elasticity/refineable_periodic_load/CMakeLists.txt
+++ b/doc/linear_elasticity/refineable_periodic_load/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered refineable_periodic_load subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(refineable_periodic_load C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/linear_solvers/CMakeLists.txt
+++ b/doc/linear_solvers/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered linear_solvers subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(linear_solvers C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/linear_wave/two_d_linear_wave/CMakeLists.txt
+++ b/doc/linear_wave/two_d_linear_wave/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_linear_wave subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_linear_wave C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/meshes/mesh_from_geompack/CMakeLists.txt
+++ b/doc/meshes/mesh_from_geompack/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered mesh_from_geompack subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(mesh_from_geompack C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/meshes/mesh_from_inline_triangle/CMakeLists.txt
+++ b/doc/meshes/mesh_from_inline_triangle/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered mesh_from_inline_triangle subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(mesh_from_inline_triangle C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/meshes/mesh_from_inline_triangle_internal_boundaries/CMakeLists.txt
+++ b/doc/meshes/mesh_from_inline_triangle_internal_boundaries/CMakeLists.txt
@@ -3,7 +3,7 @@ list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE
         "Entered mesh_from_inline_triangle_internal_boundaries subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(mesh_from_inline_triangle_internal_boundaries C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/meshes/mesh_from_tetgen/CMakeLists.txt
+++ b/doc/meshes/mesh_from_tetgen/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered mesh_from_tetgen subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(mesh_from_tetgen C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/meshes/mesh_from_triangle/CMakeLists.txt
+++ b/doc/meshes/mesh_from_triangle/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered mesh_from_triangle subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(mesh_from_triangle C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/meshes/mesh_from_vmtk/CMakeLists.txt
+++ b/doc/meshes/mesh_from_vmtk/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered mesh_from_vmtk subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(mesh_from_vmtk C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/meshes/mesh_from_xfig/CMakeLists.txt
+++ b/doc/meshes/mesh_from_xfig/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered mesh_from_xfig subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(mesh_from_xfig C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/meshes/mesh_list/CMakeLists.txt
+++ b/doc/meshes/mesh_list/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered mesh_list subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(mesh_list C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/meshes/third_party_meshes/CMakeLists.txt
+++ b/doc/meshes/third_party_meshes/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered third_party_meshes subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(third_party_meshes C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/mpi/adaptive_driven_cavity/CMakeLists.txt
+++ b/doc/mpi/adaptive_driven_cavity/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered adaptive_driven_cavity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(adaptive_driven_cavity C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/mpi/adaptive_driven_cavity_load_balance/CMakeLists.txt
+++ b/doc/mpi/adaptive_driven_cavity_load_balance/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered adaptive_driven_cavity_load_balance subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(adaptive_driven_cavity_load_balance C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/mpi/block_preconditioners/CMakeLists.txt
+++ b/doc/mpi/block_preconditioners/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered block_preconditioners subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(block_preconditioners C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/mpi/boussinesq_convection/CMakeLists.txt
+++ b/doc/mpi/boussinesq_convection/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered boussinesq_convection subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(boussinesq_convection C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/mpi/distributed_block_preconditioners/CMakeLists.txt
+++ b/doc/mpi/distributed_block_preconditioners/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered distributed_block_preconditioners subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(distributed_block_preconditioners C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/mpi/distributed_general_purpose_block_preconditioners/CMakeLists.txt
+++ b/doc/mpi/distributed_general_purpose_block_preconditioners/CMakeLists.txt
@@ -4,7 +4,7 @@ message(
   VERBOSE
   "Entered distributed_general_purpose_block_preconditioners subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(distributed_general_purpose_block_preconditioners C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/mpi/distributed_linear_algebra_infrastructure/CMakeLists.txt
+++ b/doc/mpi/distributed_linear_algebra_infrastructure/CMakeLists.txt
@@ -3,7 +3,7 @@ list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE
         "Entered distributed_linear_algebra_infrastructure subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(distributed_linear_algebra_infrastructure C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/mpi/fsi_channel_with_leaflet/CMakeLists.txt
+++ b/doc/mpi/fsi_channel_with_leaflet/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fsi_channel_with_leaflet subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fsi_channel_with_leaflet C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/mpi/general_mpi/CMakeLists.txt
+++ b/doc/mpi/general_mpi/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered general_mpi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(general_mpi C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/mpi/turek_flag/CMakeLists.txt
+++ b/doc/mpi/turek_flag/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered turek_flag subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(turek_flag C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/mpi/two_d_poisson_flux_bc_adapt/CMakeLists.txt
+++ b/doc/mpi/two_d_poisson_flux_bc_adapt/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_poisson_flux_bc_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_poisson_flux_bc_adapt C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/multi_physics/b_convection/CMakeLists.txt
+++ b/doc/multi_physics/b_convection/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered b_convection subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(b_convection C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/multi_physics/multi_domain_ref_b_convect/CMakeLists.txt
+++ b/doc/multi_physics/multi_domain_ref_b_convect/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered multi_domain_ref_b_convect subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(multi_domain_ref_b_convect C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/multi_physics/rayleigh_instability_surfactant/CMakeLists.txt
+++ b/doc/multi_physics/rayleigh_instability_surfactant/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered rayleigh_instability_surfactant subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(rayleigh_instability_surfactant C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/multi_physics/refine_b_convect/CMakeLists.txt
+++ b/doc/multi_physics/refine_b_convect/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered refine_b_convect subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(refine_b_convect C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/multi_physics/thermo/CMakeLists.txt
+++ b/doc/multi_physics/thermo/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered thermo subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(thermo C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/adaptive_bubble_in_channel/CMakeLists.txt
+++ b/doc/navier_stokes/adaptive_bubble_in_channel/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered adaptive_bubble_in_channel subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(adaptive_bubble_in_channel C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/adaptive_driven_cavity/CMakeLists.txt
+++ b/doc/navier_stokes/adaptive_driven_cavity/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered adaptive_driven_cavity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(adaptive_driven_cavity C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/adaptive_droplet_in_channel/CMakeLists.txt
+++ b/doc/navier_stokes/adaptive_droplet_in_channel/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered adaptive_droplet_in_channel subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(adaptive_droplet_in_channel C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/adaptive_interface/CMakeLists.txt
+++ b/doc/navier_stokes/adaptive_interface/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered adaptive_interface subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(adaptive_interface C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/algebraic_collapsible_channel/CMakeLists.txt
+++ b/doc/navier_stokes/algebraic_collapsible_channel/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered algebraic_collapsible_channel subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(algebraic_collapsible_channel C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/bretherton/CMakeLists.txt
+++ b/doc/navier_stokes/bretherton/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered bretherton subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(bretherton C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/channel_with_leaflet/CMakeLists.txt
+++ b/doc/navier_stokes/channel_with_leaflet/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered channel_with_leaflet subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(channel_with_leaflet C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/circular_driven_cavity/CMakeLists.txt
+++ b/doc/navier_stokes/circular_driven_cavity/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered circular_driven_cavity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(circular_driven_cavity C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/collapsible_channel/CMakeLists.txt
+++ b/doc/navier_stokes/collapsible_channel/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered collapsible_channel subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(collapsible_channel C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/curved_pipe/CMakeLists.txt
+++ b/doc/navier_stokes/curved_pipe/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered curved_pipe subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(curved_pipe C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/driven_cavity/CMakeLists.txt
+++ b/doc/navier_stokes/driven_cavity/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered driven_cavity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(driven_cavity C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/inclined_plane/CMakeLists.txt
+++ b/doc/navier_stokes/inclined_plane/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered inclined_plane subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(inclined_plane C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/jeffery_orbit/CMakeLists.txt
+++ b/doc/navier_stokes/jeffery_orbit/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered jeffery_orbit subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(jeffery_orbit C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/osc_ellipse/CMakeLists.txt
+++ b/doc/navier_stokes/osc_ellipse/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered osc_ellipse subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(osc_ellipse C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/rayleigh_channel/CMakeLists.txt
+++ b/doc/navier_stokes/rayleigh_channel/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered rayleigh_channel subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(rayleigh_channel C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/rayleigh_traction_channel/CMakeLists.txt
+++ b/doc/navier_stokes/rayleigh_traction_channel/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered rayleigh_traction_channel subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(rayleigh_traction_channel C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/single_layer_free_surface/CMakeLists.txt
+++ b/doc/navier_stokes/single_layer_free_surface/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered single_layer_free_surface subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(single_layer_free_surface C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/spine_channel/CMakeLists.txt
+++ b/doc/navier_stokes/spine_channel/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered spine_channel subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(spine_channel C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/static_single_layer/CMakeLists.txt
+++ b/doc/navier_stokes/static_single_layer/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered static_single_layer subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(static_single_layer C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/static_two_layer/CMakeLists.txt
+++ b/doc/navier_stokes/static_two_layer/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered static_two_layer subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(static_two_layer C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/surface_theory/CMakeLists.txt
+++ b/doc/navier_stokes/surface_theory/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered surface_theory subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(surface_theory C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/three_d_entry_flow/CMakeLists.txt
+++ b/doc/navier_stokes/three_d_entry_flow/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered three_d_entry_flow subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(three_d_entry_flow C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/turek_flag_non_fsi/CMakeLists.txt
+++ b/doc/navier_stokes/turek_flag_non_fsi/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered turek_flag_non_fsi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(turek_flag_non_fsi C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/two_layer_interface/CMakeLists.txt
+++ b/doc/navier_stokes/two_layer_interface/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_layer_interface subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_layer_interface C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/unstructured_fluid/CMakeLists.txt
+++ b/doc/navier_stokes/unstructured_fluid/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_fluid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_fluid C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/unstructured_three_d_fluid/CMakeLists.txt
+++ b/doc/navier_stokes/unstructured_three_d_fluid/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_three_d_fluid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_three_d_fluid C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/navier_stokes/vmtk_fluid/CMakeLists.txt
+++ b/doc/navier_stokes/vmtk_fluid/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered vmtk_fluid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(vmtk_fluid C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/optimisation/CMakeLists.txt
+++ b/doc/optimisation/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered optimisation subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(optimisation C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/order_of_action_functions/CMakeLists.txt
+++ b/doc/order_of_action_functions/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered order_of_action_functions subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(order_of_action_functions C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/paraview/CMakeLists.txt
+++ b/doc/paraview/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered paraview subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(paraview C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/people/CMakeLists.txt
+++ b/doc/people/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered people subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(people C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../")
 

--- a/doc/picture_show/CMakeLists.txt
+++ b/doc/picture_show/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered picture_show subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(picture_show C CXX Fortran)
 
 add_custom_command(

--- a/doc/pml_fourier_decomposed_helmholtz/oscillating_sphere/CMakeLists.txt
+++ b/doc/pml_fourier_decomposed_helmholtz/oscillating_sphere/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered oscillating_sphere subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(oscillating_sphere C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/pml_helmholtz/scattering/CMakeLists.txt
+++ b/doc/pml_helmholtz/scattering/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered scattering subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(scattering C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/pml_time_harmonic_linear_elasticity/CMakeLists.txt
+++ b/doc/pml_time_harmonic_linear_elasticity/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered pml_time_harmonic_linear_elasticity subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(pml_time_harmonic_linear_elasticity C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/poisson/eighth_sphere_poisson/CMakeLists.txt
+++ b/doc/poisson/eighth_sphere_poisson/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered eighth_sphere_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(eighth_sphere_poisson C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/poisson/elastic_poisson/CMakeLists.txt
+++ b/doc/poisson/elastic_poisson/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered elastic_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(elastic_poisson C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/poisson/fish_poisson/CMakeLists.txt
+++ b/doc/poisson/fish_poisson/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fish_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fish_poisson C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/poisson/fish_poisson2/CMakeLists.txt
+++ b/doc/poisson/fish_poisson2/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fish_poisson2 subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fish_poisson2 C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/poisson/one_d_poisson/CMakeLists.txt
+++ b/doc/poisson/one_d_poisson/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered one_d_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(one_d_poisson C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/poisson/two_d_poisson/CMakeLists.txt
+++ b/doc/poisson/two_d_poisson/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_poisson subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_poisson C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/poisson/two_d_poisson_adapt/CMakeLists.txt
+++ b/doc/poisson/two_d_poisson_adapt/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_poisson_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_poisson_adapt C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/poisson/two_d_poisson_flux_bc/CMakeLists.txt
+++ b/doc/poisson/two_d_poisson_flux_bc/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_poisson_flux_bc subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_poisson_flux_bc C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/poisson/two_d_poisson_flux_bc2/CMakeLists.txt
+++ b/doc/poisson/two_d_poisson_flux_bc2/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_poisson_flux_bc2 subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_poisson_flux_bc2 C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/poisson/two_d_poisson_flux_bc_adapt/CMakeLists.txt
+++ b/doc/poisson/two_d_poisson_flux_bc_adapt/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_poisson_flux_bc_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_poisson_flux_bc_adapt C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/preconditioners/fsi/CMakeLists.txt
+++ b/doc/preconditioners/fsi/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered fsi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(fsi C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/preconditioners/lgr_navier_stokes/CMakeLists.txt
+++ b/doc/preconditioners/lgr_navier_stokes/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered lgr_navier_stokes subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(lgr_navier_stokes C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/preconditioners/lsc_navier_stokes/CMakeLists.txt
+++ b/doc/preconditioners/lsc_navier_stokes/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered lsc_navier_stokes subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(lsc_navier_stokes C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/preconditioners/prescribed_displ_lagr_mult/CMakeLists.txt
+++ b/doc/preconditioners/prescribed_displ_lagr_mult/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered prescribed_displ_lagr_mult subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(prescribed_displ_lagr_mult C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/preconditioners/pseudo_solid_fsi/CMakeLists.txt
+++ b/doc/preconditioners/pseudo_solid_fsi/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered pseudo_solid_fsi subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(pseudo_solid_fsi C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/publications/CMakeLists.txt
+++ b/doc/publications/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered publications subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(publications C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/quick_guide/CMakeLists.txt
+++ b/doc/quick_guide/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered quick_guide subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(quick_guide C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/raw_doxygen/CMakeLists.txt
+++ b/doc/raw_doxygen/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered raw_doxygen subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(raw_doxygen C CXX Fortran)
 
 add_custom_target(

--- a/doc/search_results/CMakeLists.txt
+++ b/doc/search_results/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered search_results subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(search_results C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/shell/clamped_shell/CMakeLists.txt
+++ b/doc/shell/clamped_shell/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered clamped_shell subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(clamped_shell C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/solid/airy_cantilever/CMakeLists.txt
+++ b/doc/solid/airy_cantilever/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered airy_cantilever subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(airy_cantilever C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/solid/compressed_square/CMakeLists.txt
+++ b/doc/solid/compressed_square/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered compressed_square subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(compressed_square C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/solid/disk_compression/CMakeLists.txt
+++ b/doc/solid/disk_compression/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered disk_compression subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(disk_compression C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/solid/disk_oscillation/CMakeLists.txt
+++ b/doc/solid/disk_oscillation/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered disk_oscillation subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(disk_oscillation C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/solid/prescribed_displ_lagr_mult/CMakeLists.txt
+++ b/doc/solid/prescribed_displ_lagr_mult/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered prescribed_displ_lagr_mult subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(prescribed_displ_lagr_mult C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/solid/shock_disk/CMakeLists.txt
+++ b/doc/solid/shock_disk/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered shock_disk subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(shock_disk C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/solid/simple_shear/CMakeLists.txt
+++ b/doc/solid/simple_shear/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered simple_shear subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(simple_shear C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/solid/solid_theory/CMakeLists.txt
+++ b/doc/solid/solid_theory/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered solid_theory subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(solid_theory C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/solid/static_fish/CMakeLists.txt
+++ b/doc/solid/static_fish/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered static_fish subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(static_fish C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/solid/three_d_cantilever/CMakeLists.txt
+++ b/doc/solid/three_d_cantilever/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered three_d_cantilever subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(three_d_cantilever C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/solid/unstructured_adaptive_solid/CMakeLists.txt
+++ b/doc/solid/unstructured_adaptive_solid/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_adaptive_solid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_adaptive_solid C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/solid/unstructured_solid/CMakeLists.txt
+++ b/doc/solid/unstructured_solid/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_solid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_solid C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/solid/unstructured_three_d_solid/CMakeLists.txt
+++ b/doc/solid/unstructured_three_d_solid/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_three_d_solid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_three_d_solid C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/solid/vmtk_solid/CMakeLists.txt
+++ b/doc/solid/vmtk_solid/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered vmtk_solid subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(vmtk_solid C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/tar_files/CMakeLists.txt
+++ b/doc/tar_files/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered tar_files subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(tar_files C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/the_data_structure/CMakeLists.txt
+++ b/doc/the_data_structure/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered the_data_structure subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(the_data_structure C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../")
 

--- a/doc/the_distribution/CMakeLists.txt
+++ b/doc/the_distribution/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered the_distribution subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(the_distribution C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../")
 

--- a/doc/time_harmonic_fourier_decomposed_linear_elasticity/adaptive_pressure_loaded_cylinder/CMakeLists.txt
+++ b/doc/time_harmonic_fourier_decomposed_linear_elasticity/adaptive_pressure_loaded_cylinder/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered adaptive_pressure_loaded_cylinder subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(adaptive_pressure_loaded_cylinder C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/time_harmonic_fourier_decomposed_linear_elasticity/cylinder/CMakeLists.txt
+++ b/doc/time_harmonic_fourier_decomposed_linear_elasticity/cylinder/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered cylinder subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(cylinder C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/time_harmonic_linear_elasticity/elastic_annulus/CMakeLists.txt
+++ b/doc/time_harmonic_linear_elasticity/elastic_annulus/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered elastic_annulus subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(elastic_annulus C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/time_harmonic_linear_elasticity/unstructured_elastic_annulus/CMakeLists.txt
+++ b/doc/time_harmonic_linear_elasticity/unstructured_elastic_annulus/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered unstructured_elastic_annulus subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(unstructured_elastic_annulus C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/to_be_written/CMakeLists.txt
+++ b/doc/to_be_written/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered to_be_written subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(to_be_written C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 

--- a/doc/unsteady_heat/two_d_unsteady_heat/CMakeLists.txt
+++ b/doc/unsteady_heat/two_d_unsteady_heat/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_unsteady_heat subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_unsteady_heat C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/unsteady_heat/two_d_unsteady_heat2/CMakeLists.txt
+++ b/doc/unsteady_heat/two_d_unsteady_heat2/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_unsteady_heat2 subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_unsteady_heat2 C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/unsteady_heat/two_d_unsteady_heat_2adapt/CMakeLists.txt
+++ b/doc/unsteady_heat/two_d_unsteady_heat_2adapt/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_unsteady_heat_2adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_unsteady_heat_2adapt C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../")
 

--- a/doc/unsteady_heat/two_d_unsteady_heat_ALE/CMakeLists.txt
+++ b/doc/unsteady_heat/two_d_unsteady_heat_ALE/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_unsteady_heat_ALE subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_unsteady_heat_ALE C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/unsteady_heat/two_d_unsteady_heat_adapt/CMakeLists.txt
+++ b/doc/unsteady_heat/two_d_unsteady_heat_adapt/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_unsteady_heat_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_unsteady_heat_adapt C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/unsteady_heat/two_d_unsteady_heat_t_adapt/CMakeLists.txt
+++ b/doc/unsteady_heat/two_d_unsteady_heat_t_adapt/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered two_d_unsteady_heat_t_adapt subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(two_d_unsteady_heat_t_adapt C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/young_laplace/contact_angle/CMakeLists.txt
+++ b/doc/young_laplace/contact_angle/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered contact_angle subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(contact_angle C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/doc/young_laplace/young_laplace/CMakeLists.txt
+++ b/doc/young_laplace/young_laplace/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered young_laplace subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(young_laplace C CXX Fortran)
 set(OOMPH_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 

--- a/external_distributions/cmake/OomphGetExternalTrilinos.cmake
+++ b/external_distributions/cmake/OomphGetExternalTrilinos.cmake
@@ -25,10 +25,13 @@ set(TRILINOS_GIT_TAG trilinos-release-16-0-0)
 set(TRILINOS_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/trilinos")
 
 # TODO: Handle deprecated packages more gracefully
-message(
-  WARNING
-    "Disabling deprecated Trilinos package warnings. Do not move past v16.0.0 without making the necessary oomph-lib changes to handle this."
-)
+if (NOT TRILINOS_GIT_TAG STREQUAL "trilinos-release-16-0-0")
+  message(
+    WARNING
+      "Disabling deprecated Trilinos package warnings. Do not move past v16.0.0 "
+      "without making the necessary oomph-lib changes to handle this."
+  )
+endif()
 
 # On Ubuntu, Trilinos doesn't appear to link to gfortran when using OpenBLAS,
 # resulting in error described here:

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered scripts subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(scripts C CXX Fortran)
 if(PROJECT_IS_TOP_LEVEL)
   find_package(oomphlib CONFIG REQUIRED PATHS "../install")

--- a/scripts/install_cmake.sh
+++ b/scripts/install_cmake.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# A tiny helper that downloads and installs a recent CMake (>= 3.24).
+# It follows the exact steps documented in README.md.
+#
+# Usage:
+#   ./scripts/install_cmake.sh                # install 3.24.4 under ~/.cmake-3.24.4
+#   CMAKE_VERSION=3.25.3 ./scripts/install_cmake.sh   # choose a different version
+#   CMAKE_DEST_DIR=$HOME/opt/cmake ./scripts/install_cmake.sh  # choose destination
+#
+# After it finishes, it prints an export line you can add to ~/.bashrc or ~/.zshrc.
+
+set -euo pipefail
+
+CMAKE_VERSION="${CMAKE_VERSION:-3.24.4}"
+CMAKE_DEST_DIR="${CMAKE_DEST_DIR:-$HOME/.local/.cmake-${CMAKE_VERSION}}"
+
+if [ -d ${CMAKE_DEST_DIR} ]; then
+    echo "Desired installation directory for CMake, i.e."
+    echo
+    echo "      ${CMAKE_DEST_DIR}"
+    echo
+    echo "already exists!"
+    exit 1
+fi
+
+# Resolve OS
+OS="$(uname -s)"
+TMP="$(mktemp)"
+
+# Helper message
+function final_instructions() {
+    echo
+    echo "CMake ${CMAKE_VERSION} installed to:"
+    echo
+    echo "      ${CMAKE_DEST_DIR}"
+    echo
+    echo "Add the following line to your shell start-up file to make it permanent:"
+    echo
+    echo "      export PATH=${1}:\$PATH"
+}
+
+case "$OS" in
+Linux*)
+    echo "Installing CMake ${CMAKE_VERSION} for Linux ..."
+    mkdir -p "${CMAKE_DEST_DIR}"
+    URL="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh"
+    curl -L "${URL}" -o "${TMP}"
+    chmod +x "${TMP}"
+    bash "${TMP}" --prefix="${CMAKE_DEST_DIR}" --exclude-subdir
+    rm -f "${TMP}"
+    final_instructions "${CMAKE_DEST_DIR}/bin"
+    ;;
+
+Darwin*)
+    echo "Installing CMake ${CMAKE_VERSION} for macOS ..."
+    URL="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-macos-universal.tar.gz"
+    curl -sL "${URL}" -o "${TMP}"
+    tar -xzf "${TMP}"
+    mv "cmake-${CMAKE_VERSION}-macos-universal" "${CMAKE_DEST_DIR}"
+    rm -f "${TMP}"
+    final_instructions "${CMAKE_DEST_DIR}/CMake.app/Contents/bin"
+    ;;
+
+*)
+    echo "Unsupported OS: ${OS} — please install CMake manually." >&2
+    exit 1
+    ;;
+esac

--- a/user_drivers/CMakeLists.txt
+++ b/user_drivers/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered user_drivers subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(demo_drivers C CXX Fortran)
 if(NOT oomphlib_FOUND)
   find_package(oomphlib CONFIG REQUIRED PATHS "../install")

--- a/user_drivers/joe_cool/CMakeLists.txt
+++ b/user_drivers/joe_cool/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND CMAKE_MESSAGE_INDENT " ")
 message(VERBOSE "Entered joe_cool subdirectory")
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 project(one_d_poisson C CXX Fortran)
 if(NOT oomphlib_FOUND)
   find_package(oomphlib CONFIG REQUIRED PATHS "../../install")


### PR DESCRIPTION
## Summary of changes

- [Fixed naming in workflows](https://github.com/oomph-lib/oomph-lib/commit/7c0cfded8ab4bc58ee2e215ee15bb47fe1560f11) to avoid confusion.
- [Made all `CMakeLists.txt` files require CMake 3.24](https://github.com/oomph-lib/oomph-lib/commit/6d840b81698408015385a3a833149144bf3deda9). For some reason, most required CMake version 3.22 apart from the top-level `CMakeLists.txt` and the `external_distributions/` one.
- [Changed when the Trilinos version warning gets printed](https://github.com/oomph-lib/oomph-lib/commit/16bb4f0dd9161ea2c73aed694dfd1b4487cba64a); we'll now only do it if it changes from v16.0.0. Makes the CMake output cleaner for new users.
- [Add CMake version check to `oomph_build.py` and `scripts/install_cmake.sh`](https://github.com/oomph-lib/oomph-lib/commit/af1ca75c68e2a56f815253dde29b627b81c0469f) to help guide new users with CMake installation problems.

## Self-tests

See latest workflow runs [here](https://github.com/puneetmatharu/oomph-lib/actions?query=branch%3Acmake-beta).