### PR TITLE
Patch `split_extra_options(...)` in `oomph_build.py`

### DIFF
--- a/oomph_build.py
+++ b/oomph_build.py
@@ -519,8 +519,7 @@ def parse_args():
     # >>> split_extra_options(s)
     # ['-DCMAKE_C_COMPILER="/usr/bin/gcc"', '-DCMAKE_CXX_COMPILER="/usr/bin/g++"']
     def split_extra_options(option_string: str):
-        (first_option, *other_options) = option_string.split(" -D")
-        return [first_option] + [f"-D{opt}" for opt in other_options]
+        return shlex.split(option_string)
 
     if args.oomph_extra_cmake_options is not None:
         args.oomph_extra_cmake_options = split_extra_options(


### PR DESCRIPTION
The previous implementation failed to split the command in the way that the `subprocess` module would like, e.g.

```bash
./oomph_build.py [...] --oomph-extra-cmake-options="-DCMAKE_C_COMPILER=\"/usr/bin/gcc\""
```

would cause problems because the quotes around `/usr/bin/gcc` were not parsed on the Python side correctly before being passed to `subprocess.run` (which doesn't run the command quite like a shell command, for safety).