### PR TITLE
Tweak custom `oomph_[path_]option` for `ccmake` visibility

### DIFF
--- a/external_distributions/CMakeLists.txt
+++ b/external_distributions/CMakeLists.txt
@@ -67,7 +67,7 @@ set(CMAKE_MESSAGE_LOG_LEVEL VERBOSE)
 
 # ------------------------------[ BUILD OPTIONS ]-------------------------------
 # cmake-format: off
-include(OomphOptions)
+include(OomphCustomOptions)
 
 # Boolean options
 oomph_option(OOMPH_ENABLE_MPI "Build third-party libraries with MPI support?" OFF)


### PR DESCRIPTION
Makes sure to define CMake cache variables for all path type options. Note that if you don't provide the required ones, CMake will die early (because we tell you straight away that you haven't provided it) and your cache won't contain the later path cache variables. Therefore, to get a full view of the path variables, you'll need to also provide the bare basic arguments (i.e. where are OpenBLAS, SuperLU, GKlib and METIS) to finish the configuration and see all the variables in the `ccmake` "GUI" \**ahem*\*.

Tests pass! [Ubuntu](https://github.com/puneetmatharu/oomph-lib/actions/runs/18404875142) and [macOS](https://github.com/puneetmatharu/oomph-lib/actions/runs/18404875123).