### PR TITLE
Update READMEs to reflect up-to-date CMake branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
         <th>Test platform</th>
         <th><a href="../../tree/main"><code>main</code></a></th>
         <th><a href="../../tree/development"><code>development</code></a></th>
-        <th><a href="../../tree/feature-shared-cmake"><code>feature-shared-cmake</code></a></th>
+        <th><a href="../../tree/cmake-beta"><code>cmake-beta</code></a></th>
     </tr>
     <tr>
         <td>Ubuntu</td>
@@ -38,7 +38,7 @@
         <td>
           <div align="center">
               <a href="../../actions/workflows/self-tests-ubuntu.yaml">
-                  <img alt="Ubuntu" src="../../actions/workflows/self-tests-ubuntu.yaml/badge.svg?branch=feature-shared-cmake" style="vertical-align: middle">
+                  <img alt="Ubuntu" src="../../actions/workflows/self-tests-ubuntu.yaml/badge.svg?branch=cmake-beta" style="vertical-align: middle">
               </a>
           </div>
         </td>
@@ -58,7 +58,7 @@
         <td>
           <div align="center">
               <a href="../../actions/workflows/self-tests-macos.yaml">
-                  <img alt="macOS" src="../../actions/workflows/self-tests-macos.yaml/badge.svg?branch=feature-shared-cmake" style="vertical-align: middle">
+                  <img alt="macOS" src="../../actions/workflows/self-tests-macos.yaml/badge.svg?branch=cmake-beta" style="vertical-align: middle">
               </a>
           </div>
         </td>

--- a/external_distributions/README.md
+++ b/external_distributions/README.md
@@ -16,13 +16,13 @@
     <table>
     <tr>
         <th>Test platform</th>
-        <th><a href="../../../tree/feature-shared-cmake"><code>feature-shared-cmake</code></a></th>
+        <th><a href="../../../tree/cmake-beta"><code>cmake-beta</code></a></th>
     </tr>
     <tr>
         <td>Ubuntu</td>
         <td>
             <a href="../../../actions/workflows/test-third-party-libs-on-ubuntu.yaml">
-                <img alt="Ubuntu" src="../../../actions/workflows/test-third-party-libs-on-ubuntu.yaml/badge.svg?branch=feature-shared-cmake" style="vertical-align: middle">
+                <img alt="Ubuntu" src="../../../actions/workflows/test-third-party-libs-on-ubuntu.yaml/badge.svg?branch=cmake-beta" style="vertical-align: middle">
             </a>
         </td>
     </tr>
@@ -30,7 +30,7 @@
         <td>macOS</td>
         <td>
             <a href="../../../actions/workflows/test-third-party-libs-on-macos.yaml">
-                <img alt="macOS" src="../../../actions/workflows/test-third-party-libs-on-macos.yaml/badge.svg?branch=feature-shared-cmake" style="vertical-align: middle">
+                <img alt="macOS" src="../../../actions/workflows/test-third-party-libs-on-macos.yaml/badge.svg?branch=cmake-beta" style="vertical-align: middle">
             </a>
         </td>
     </tr>
@@ -59,7 +59,7 @@ Tool    | Version
 --------|--------
 `CMake` | 3.24
 
-If you cannot obtain a recent enough version of CMake via your favourite package manager, you will need to build it from source. Worry not however, this is a straightforward task. For details on how to do this, see [the instructions here](https://github.com/puneetmatharu/oomph-lib/tree/feature-shared-cmake#building-cmake).
+If you cannot obtain a recent enough version of CMake via your favourite package manager, you will need to build it from source. Worry not however, this is a straightforward task. For details on how to do this, see [the instructions here](https://github.com/puneetmatharu/oomph-lib/tree/cmake-beta#building-cmake).
 
 ## Library versions
 


### PR DESCRIPTION
Does what it says on the ~tin~ subject line. 