### PR TITLE
Clean up leftover `cmake-beta`-isms

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@
         <th>Test platform</th>
         <th><a href="../../tree/main"><code>main</code></a></th>
         <th><a href="../../tree/development"><code>development</code></a></th>
-        <th><a href="../../tree/cmake-beta"><code>cmake-beta</code></a></th>
     </tr>
     <tr>
         <td>Ubuntu</td>
@@ -35,13 +34,6 @@
                 <img alt="Ubuntu" src="../../actions/workflows/self-tests-ubuntu.yaml/badge.svg?branch=development" style="vertical-align: middle">
             </a>
         </td>
-        <td>
-          <div align="center">
-              <a href="../../actions/workflows/self-tests-ubuntu.yaml">
-                  <img alt="Ubuntu" src="../../actions/workflows/self-tests-ubuntu.yaml/badge.svg?branch=cmake-beta" style="vertical-align: middle">
-              </a>
-          </div>
-        </td>
     </tr>
     <tr>
         <td>macOS</td>
@@ -54,13 +46,6 @@
             <a href="../../actions/workflows/self-tests-macos.yaml">
                 <img alt="macOS" src="../../actions/workflows/self-tests-macos.yaml/badge.svg?branch=development" style="vertical-align: middle">
             </a>
-        </td>
-        <td>
-          <div align="center">
-              <a href="../../actions/workflows/self-tests-macos.yaml">
-                  <img alt="macOS" src="../../actions/workflows/self-tests-macos.yaml/badge.svg?branch=cmake-beta" style="vertical-align: middle">
-              </a>
-          </div>
         </td>
     </tr>
     </table>

--- a/external_distributions/CMakeLists.txt
+++ b/external_distributions/CMakeLists.txt
@@ -135,12 +135,6 @@ else()
   message(STATUS "Number of jobs for parallel make: ${OOMPH_NUM_JOBS}")
 endif()
 
-# Where to download files from and where to install to TODO: Upload HYPRE and
-# Trilinos here
-set(OOMPH_THIRD_PARTY_TAR_FILE_URL
-    "https://github.com/puneetmatharu/oomph-lib/releases/download/v3.0.0.pre-alpha"
-)
-
 # ----------------------------------[ MPI ]------------------------------------
 
 # Set up MPI functionality (see cmake/OomphMPI.cmake)

--- a/external_distributions/README.md
+++ b/external_distributions/README.md
@@ -16,13 +16,19 @@
     <table>
     <tr>
         <th>Test platform</th>
-        <th><a href="../../../tree/cmake-beta"><code>cmake-beta</code></a></th>
+        <th><a href="../../../tree/main"><code>main</code></a></th>
+        <th><a href="../../../tree/development"><code>development</code></a></th>
     </tr>
     <tr>
         <td>Ubuntu</td>
         <td>
             <a href="../../../actions/workflows/test-third-party-libs-on-ubuntu.yaml">
-                <img alt="Ubuntu" src="../../../actions/workflows/test-third-party-libs-on-ubuntu.yaml/badge.svg?branch=cmake-beta" style="vertical-align: middle">
+                <img alt="Ubuntu" src="../../../actions/workflows/test-third-party-libs-on-ubuntu.yaml/badge.svg?branch=main" style="vertical-align: middle">
+            </a>
+        </td>
+        <td>
+            <a href="../../../actions/workflows/test-third-party-libs-on-ubuntu.yaml">
+                <img alt="Ubuntu" src="../../../actions/workflows/test-third-party-libs-on-ubuntu.yaml/badge.svg?branch=development" style="vertical-align: middle">
             </a>
         </td>
     </tr>
@@ -30,7 +36,12 @@
         <td>macOS</td>
         <td>
             <a href="../../../actions/workflows/test-third-party-libs-on-macos.yaml">
-                <img alt="macOS" src="../../../actions/workflows/test-third-party-libs-on-macos.yaml/badge.svg?branch=cmake-beta" style="vertical-align: middle">
+                <img alt="macOS" src="../../../actions/workflows/test-third-party-libs-on-macos.yaml/badge.svg?branch=main" style="vertical-align: middle">
+            </a>
+        </td>
+        <td>
+            <a href="../../../actions/workflows/test-third-party-libs-on-macos.yaml">
+                <img alt="macOS" src="../../../actions/workflows/test-third-party-libs-on-macos.yaml/badge.svg?branch=development" style="vertical-align: middle">
             </a>
         </td>
     </tr>
@@ -59,7 +70,7 @@ Tool    | Version
 --------|--------
 `CMake` | 3.24
 
-If you cannot obtain a recent enough version of CMake via your favourite package manager, you will need to build it from source. Worry not however, this is a straightforward task. For details on how to do this, see [the instructions here](https://github.com/puneetmatharu/oomph-lib/tree/cmake-beta#building-cmake).
+If you cannot obtain a recent enough version of CMake via your favourite package manager, you will need to build it from source. Worry not however, this is a straightforward task. For details on how to do this, see [the instructions here](https://github.com/oomph-lib/oomph-lib/tree/main#building-cmake).
 
 ## Library versions
 

--- a/scripts/how_to_build_and_test_example.bash
+++ b/scripts/how_to_build_and_test_example.bash
@@ -16,7 +16,7 @@ set -o nounset
 #==========================================
 
 # clone repos?
-oomphlib_branch="cmake-beta"
+oomphlib_branch="development"
 clone_oomphlib=1
 clone_stand_alone_code=1
 


### PR DESCRIPTION
I've deleted the `cmake-beta` branch from the main repo so we have our `main` and `development` branches now. I completely forgot to wipe the beta CMake stuff. Done here.