### PR TITLE
Update MUMPS support

### DIFF
--- a/.github/actions/cache-mumps/action.yaml
+++ b/.github/actions/cache-mumps/action.yaml
@@ -1,0 +1,48 @@
+--- # ------------------------------------------------------------------------------
+
+name: Cache MUMPS tarball
+description: Restore/download/cache MUMPS tarball
+inputs:
+  mumps-version:
+    description: MUMPS upstream version, e.g. 5.8.1
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Prepare tarball directory
+      shell: bash
+      run: mkdir -p external_distributions/tarballs
+
+    - name: Restore cached MUMPS tarball
+      id: mumps-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: external_distributions/tarballs
+        key: mumps-${{ inputs.mumps-version }}
+
+    - name: Download MUMPS tarball if missing
+      if: steps.mumps-cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        MUMPS_UPSTREAM_VERSION: ${{ inputs.mumps-version }}
+      run: |
+        set -e
+        FILE="MUMPS_${MUMPS_UPSTREAM_VERSION}.tar.gz"
+        DEST="external_distributions/tarballs/${FILE}"
+        URL="https://mumps-solver.org/${FILE}"
+
+        if [ -f "$DEST" ]; then
+          echo "Using existing MUMPS tarball at $DEST"
+        else
+          echo "Cache miss, downloading $URL to $DEST"
+          curl --fail --location --retry 5 --retry-delay 5 -o "$DEST" "$URL"
+        fi
+
+    - name: Save MUMPS tarball cache
+      if: steps.mumps-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: external_distributions/tarballs
+        key: ${{ steps.mumps-cache.outputs.cache-primary-key }}
+# ------------------------------------------------------------------------------

--- a/.github/actions/restore-mumps/action.yaml
+++ b/.github/actions/restore-mumps/action.yaml
@@ -1,0 +1,32 @@
+--- # ------------------------------------------------------------------------------
+
+name: Restore MUMPS tarball
+description: Restore MUMPS tarball from cache and export OOMPH_MUMPS_TARBALL_PATH
+inputs:
+  mumps-version:
+    description: MUMPS version, e.g. 5.8.1
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Restore MUMPS tarball cache
+      uses: actions/cache/restore@v4
+      id: mumps-cache
+      with:
+        path: external_distributions/tarballs
+        key: mumps-${{ inputs.mumps-version }}
+
+    - name: Export OOMPH_MUMPS_TARBALL_PATH
+      shell: bash
+      run: |
+        FILE="MUMPS_${{ inputs.mumps-version }}.tar.gz"
+        DEST="${GITHUB_WORKSPACE}/external_distributions/tarballs/${FILE}"
+        if [ ! -f "$DEST" ]; then
+          echo "ERROR: MUMPS tarball not found at $DEST"
+          echo "Did the cache-mumps job run?"
+          exit 1
+        fi
+        echo "OOMPH_MUMPS_TARBALL_PATH=$DEST" >> "$GITHUB_ENV"
+
+# ------------------------------------------------------------------------------

--- a/.github/workflows/self-tests-macos.yaml
+++ b/.github/workflows/self-tests-macos.yaml
@@ -58,11 +58,29 @@ on:
 # Environment variables that can be read during jobs
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
+  MUMPS_UPSTREAM_VERSION: &mumps_upstream_version 5.8.1
 
 # ------------------------------------------------------------------------------
 
 jobs:
+  cache-mumps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Grab actions (only) from oomph-lib repository
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
+      - name: Cache / download MUMPS tarball
+        uses: ./.github/actions/cache-mumps
+        with:
+          mumps-version: *mumps_upstream_version
+
   build:
+    needs: cache-mumps
     strategy:
       fail-fast: false
       matrix:
@@ -88,6 +106,11 @@ jobs:
       - name: Install MPI dependencies (if required)
         if: matrix.build_info.enable_mpi == 'ON'
         run: brew install open-mpi
+
+      - name: Restore MUMPS tarball
+        uses: ./.github/actions/restore-mumps
+        with:
+          mumps-version: *mumps_upstream_version
 
       - name: Configure ccache
         run: |
@@ -158,6 +181,7 @@ jobs:
              --ext-OOMPH_BUILD_HYPRE=${{ matrix.build_third_party_libs }} \
              --ext-OOMPH_BUILD_MUMPS=${{ matrix.build_third_party_libs }} \
              --ext-OOMPH_BUILD_TRILINOS=${{ matrix.build_third_party_libs }} \
+             --ext-OOMPH_MUMPS_TARBALL_PATH="${OOMPH_MUMPS_TARBALL_PATH}" \
              --no-build-oomph \
              --verbose
 

--- a/.github/workflows/self-tests-ubuntu.yaml
+++ b/.github/workflows/self-tests-ubuntu.yaml
@@ -58,11 +58,29 @@ on:
 # Environment variables that can be read during jobs
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
+  MUMPS_UPSTREAM_VERSION: &mumps_upstream_version 5.8.1
 
 # ------------------------------------------------------------------------------
 
 jobs:
+  cache-mumps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Grab actions (only) from oomph-lib repository
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
+      - name: Cache / download MUMPS tarball
+        uses: ./.github/actions/cache-mumps
+        with:
+          mumps-version: *mumps_upstream_version
+
   build:
+    needs: cache-mumps
     strategy:
       fail-fast: false
       matrix:
@@ -88,6 +106,11 @@ jobs:
       - name: Install MPI dependencies (if required)
         if: matrix.build_info.enable_mpi == 'ON'
         run: sudo apt-get install -y openmpi-bin libopenmpi-dev ccache
+
+      - name: Restore MUMPS tarball
+        uses: ./.github/actions/restore-mumps
+        with:
+          mumps-version: *mumps_upstream_version
 
       - name: Configure ccache
         run: |
@@ -158,6 +181,7 @@ jobs:
              --ext-OOMPH_BUILD_HYPRE=${{ matrix.build_third_party_libs }} \
              --ext-OOMPH_BUILD_MUMPS=${{ matrix.build_third_party_libs }} \
              --ext-OOMPH_BUILD_TRILINOS=${{ matrix.build_third_party_libs }} \
+             --ext-OOMPH_MUMPS_TARBALL_PATH="${OOMPH_MUMPS_TARBALL_PATH}" \
              --no-build-oomph \
              --verbose
 

--- a/.github/workflows/test-third-party-libs-on-macos.yaml
+++ b/.github/workflows/test-third-party-libs-on-macos.yaml
@@ -32,11 +32,29 @@ env:
   # Enable oversubscription for OpenMPI to handle MPI-enabled tests requiring
   # more processors than are available
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  MUMPS_UPSTREAM_VERSION: &mumps_upstream_version 5.8.1
 
 # ------------------------------------------------------------------------------
 
 jobs:
+  cache-mumps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Grab actions (only) from oomph-lib repository
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
+      - name: Cache / download MUMPS tarball
+        uses: ./.github/actions/cache-mumps
+        with:
+          mumps-version: *mumps_upstream_version
+
   build:
+    needs: cache-mumps
     strategy:
       fail-fast: false
       matrix:
@@ -54,6 +72,11 @@ jobs:
         if: matrix.mpi == 'ON'
         run: brew install open-mpi
 
+      - name: Restore MUMPS tarball
+        uses: ./.github/actions/restore-mumps
+        with:
+          mumps-version: *mumps_upstream_version
+
       - name: Get CMake v3.24
         uses: lukka/get-cmake@latest
         with:
@@ -69,6 +92,7 @@ jobs:
              --OOMPH_ENABLE_MPI=${{ matrix.mpi }} \
              --ext-OOMPH_ENABLE_THIRD_PARTY_LIBRARY_TESTS=ON \
              --ext-OOMPH_USE_OPENBLAS_FROM=$(brew --prefix openblas) \
+             --ext-OOMPH_MUMPS_TARBALL_PATH="${OOMPH_MUMPS_TARBALL_PATH}" \
              --no-build-oomph \
              --verbose
         continue-on-error: true

--- a/.github/workflows/test-third-party-libs-on-ubuntu.yaml
+++ b/.github/workflows/test-third-party-libs-on-ubuntu.yaml
@@ -32,11 +32,29 @@ env:
   # Enable oversubscription for OpenMPI to handle MPI-enabled tests requiring
   # more processors than are available
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  MUMPS_UPSTREAM_VERSION: &mumps_upstream_version 5.8.1
 
 # ------------------------------------------------------------------------------
 
 jobs:
+  cache-mumps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Grab actions (only) from oomph-lib repository
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
+      - name: Cache / download MUMPS tarball
+        uses: ./.github/actions/cache-mumps
+        with:
+          mumps-version: *mumps_upstream_version
+
   build:
+    needs: cache-mumps
     strategy:
       fail-fast: false
       matrix:
@@ -54,6 +72,11 @@ jobs:
         if: matrix.mpi == 'ON'
         run: sudo apt-get install -y openmpi-bin libopenmpi-dev
 
+      - name: Restore MUMPS tarball
+        uses: ./.github/actions/restore-mumps
+        with:
+          mumps-version: *mumps_upstream_version
+
       - name: Get CMake v3.24
         uses: lukka/get-cmake@latest
         with:
@@ -63,12 +86,12 @@ jobs:
         run: cmake --version
 
       - name: Configure, build, and install
-
         id: build
         run: |
           python3 oomph_build.py \
             --OOMPH_ENABLE_MPI=${{ matrix.mpi }} \
             --ext-OOMPH_ENABLE_THIRD_PARTY_LIBRARY_TESTS=ON \
+            --ext-OOMPH_MUMPS_TARBALL_PATH="${OOMPH_MUMPS_TARBALL_PATH}" \
             --no-build-oomph \
             --verbose
         continue-on-error: true

--- a/external_distributions/CMakeLists.txt
+++ b/external_distributions/CMakeLists.txt
@@ -106,6 +106,10 @@ oomph_path_option(
   FLAG OOMPH_USE_BOOST_FROM
   DOCSTRING "The path to a preinstalled version of Boost."
 )
+oomph_path_option(
+  FLAG OOMPH_MUMPS_TARBALL_PATH
+  DOCSTRING "The path to a preinstalled version of Boost."
+)
 
 # cmake-format: on
 # ----------------------[ FIND REQUIRED/DESIRED PACKAGES ]----------------------

--- a/external_distributions/cmake/OomphGetExternalMUMPS.cmake
+++ b/external_distributions/cmake/OomphGetExternalMUMPS.cmake
@@ -23,26 +23,29 @@ include_guard()
 
 # Where to get the code from and where to install it to
 set(MUMPS_GIT_URL https://github.com/puneetmatharu/mumps.git)
-set(MUMPS_GIT_TAG v5.6.2.5)
+set(MUMPS_GIT_TAG v5.8.1.3-pm)
+set(MUMPS_UPSTREAM_VERSION 5.8.1)
 set(MUMPS_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/mumps")
 
 # MUMPS build options
 set(MUMPS_CMAKE_CONFIGURE_ARGS
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     -DCMAKE_INSTALL_PREFIX=${MUMPS_INSTALL_DIR}
-    -DMUMPS_UPSTREAM_VERSION=5.6.2
-    -Dparallel=${OOMPH_ENABLE_MPI}
-    # -Dfind_static=ON # FIXME: Doesn't work on macOS!
+    -DMUMPS_UPSTREAM_VERSION=${MUMPS_UPSTREAM_VERSION}
+    -DMUMPS_parallel=${OOMPH_ENABLE_MPI}
+    -DMUMPS_scalapack=ON
+    -DMUMPS_find_SCALAPACK=OFF
+    # -Dfind_static=OFF # NOTE: using ON doesn't work on macOS!
+    -DMUMPS_find_static=OFF # NOTE: using ON doesn't work on macOS!
     -Dgemmt=ON
-    -Dintsize64=OFF
-    -Dscotch=OFF
-    -Dparmetis=OFF
-    -Dmetis=OFF
-    -Dopenmp=OFF
-    -Dmatlab=OFF
-    -Doctave=OFF
-    -Dfind=OFF
-    -DBUILD_TESTING=${OOMPH_ENABLE_THIRD_PARTY_LIBRARY_TESTS}
+    -DMUMPS_intsize64=OFF
+    -DMUMPS_scotch=OFF
+    -DMUMPS_parmetis=OFF
+    -DMUMPS_metis=OFF
+    -DMUMPS_openmp=OFF
+    -DMUMPS_matlab=OFF
+    -DSCALAPACK_BUILD_TESTING=${OOMPH_ENABLE_THIRD_PARTY_LIBRARY_TESTS}
+    -DMUMPS_BUILD_TESTING=${OOMPH_ENABLE_THIRD_PARTY_LIBRARY_TESTS}
     -DBUILD_SHARED_LIBS=OFF
     -DBUILD_SINGLE=ON
     -DBUILD_DOUBLE=ON
@@ -50,6 +53,18 @@ set(MUMPS_CMAKE_CONFIGURE_ARGS
     -DBUILD_COMPLEX16=OFF
     -DLAPACK_VENDOR=OpenBLAS
     -DLAPACK_ROOT=${OpenBLAS_ROOT})
+
+if(NOT OOMPH_MUMPS_TARBALL_PATH STREQUAL "")
+  if(EXISTS "${OOMPH_MUMPS_TARBALL_PATH}")
+    list(APPEND MUMPS_CMAKE_CONFIGURE_ARGS
+         "-DMUMPS_url=${OOMPH_MUMPS_TARBALL_PATH}")
+  else()
+    message(
+      FATAL_ERROR
+        "OOMPH_MUMPS_TARBALL_PATH was set but the file does not exist:\n"
+        "  ${OOMPH_MUMPS_TARBALL_PATH}")
+  endif()
+endif()
 
 # Define how to configure/build/install the project
 oomph_get_external_project_helper(

--- a/oomph_build.py
+++ b/oomph_build.py
@@ -486,6 +486,7 @@ def parse_args():
     ext_group.add_argument("--ext-OOMPH_USE_METIS_FROM", type=expanded_path, metavar="PATH", help="Use a preinstalled METIS from the given path; used by SuperLU.")
     ext_group.add_argument("--ext-OOMPH_USE_PARMETIS_FROM", type=expanded_path, metavar="PATH", help="Use a preinstalled ParMETIS from the given path; used by SuperLU_DIST.")
     ext_group.add_argument("--ext-OOMPH_USE_BOOST_FROM", type=expanded_path, metavar="PATH", help="Use a preinstalled Boost from the given path; used by CGAL.")
+    ext_group.add_argument("--ext-OOMPH_MUMPS_TARBALL_PATH", type=expanded_path, metavar="PATH", help="The path to the pre-downloaded MUMPS tarball. WARNING: Make sure this tarball matches the MUMPS_UPSTREAM_VERSION we're using!")
 
     # Any additional flags for the external distributions project
     ext_group.add_argument("--ext-extra-cmake-options", type=shlex.split, metavar="OPTIONS", help="Additional raw CMake flags for external_distributions (e.g. --ext-extra-cmake-options='-DCMAKE_C_COMPILER=/path/to/gcc -DCMAKE_CXX_COMPILER=/path/to/g++').")


### PR DESCRIPTION
Updates include:
 - Updated to use the latest changes from my MUMPS fork (pulls in the latest changes from the main MUMPS repo which means we can provide our own MUMPS tarball).
 - Switched to latest upstream MUMPS version (i.e. the tarball version).
 - Add composite actions to cache MUMPS tarball (`.github/actions/cache-mumps/action.yaml`) and reuse (`.github/actions/restore-mumps/action.yaml`) across jobs.