### PR TITLE
Respect CMake build parallelism in CTest runs + add option to wipe Validation directories after self-test pass

### DIFF
--- a/.github/workflows/self-tests-macos.yaml
+++ b/.github/workflows/self-tests-macos.yaml
@@ -59,6 +59,7 @@ on:
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
   MUMPS_UPSTREAM_VERSION: &mumps_upstream_version 5.8.1
+  OOMPH_DELETE_VALIDATION_DIRECTORY_AFTER_SUCCESSFUL_TEST: "yes"
 
 # ------------------------------------------------------------------------------
 
@@ -235,6 +236,15 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             --log-level=VERBOSE
 
+      - name: Print demo driver disk usage before self-tests
+        run: |
+          df -h .
+          if [ -d demo_drivers/build ]; then
+            echo "Largest entries in demo_drivers/build:"
+            du -sk demo_drivers/build/* 2>/dev/null | sort -n | tail -30 | awk '{printf "%10.1f MiB  %s\n", $1 / 1024, $2}'
+          fi
+        continue-on-error: true
+
       - name: Run demo driver self-tests
         id: demo_drivers
         run: |
@@ -243,6 +253,16 @@ jobs:
 
           # Print a test summary at the end
           python3 .github/generate_validation_log_summary.py validation.log
+        continue-on-error: true
+
+      - name: Print demo driver disk usage after self-tests
+        if: always()
+        run: |
+          df -h .
+          if [ -d demo_drivers/build ]; then
+            echo "Largest entries in demo_drivers/build:"
+            du -sk demo_drivers/build/* 2>/dev/null | sort -n | tail -30 | awk '{printf "%10.1f MiB  %s\n", $1 / 1024, $2}'
+          fi
         continue-on-error: true
 
       - name: Clean up after self-tests

--- a/.github/workflows/self-tests-ubuntu.yaml
+++ b/.github/workflows/self-tests-ubuntu.yaml
@@ -59,6 +59,7 @@ on:
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
   MUMPS_UPSTREAM_VERSION: &mumps_upstream_version 5.8.1
+  OOMPH_DELETE_VALIDATION_DIRECTORY_AFTER_SUCCESSFUL_TEST: "yes"
 
 # ------------------------------------------------------------------------------
 
@@ -242,6 +243,15 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             --log-level=VERBOSE
 
+      - name: Print demo driver disk usage before self-tests
+        run: |
+          df -h .
+          if [ -d demo_drivers/build ]; then
+            echo "Largest entries in demo_drivers/build:"
+            du -sk demo_drivers/build/* 2>/dev/null | sort -n | tail -30 | awk '{printf "%10.1f MiB  %s\n", $1 / 1024, $2}'
+          fi
+        continue-on-error: true
+
       - name: Run demo driver self-tests
         id: demo_drivers
         run: |
@@ -250,6 +260,16 @@ jobs:
 
           # Print a test summary at the end
           python3 .github/generate_validation_log_summary.py validation.log
+        continue-on-error: true
+
+      - name: Print demo driver disk usage after self-tests
+        if: always()
+        run: |
+          df -h .
+          if [ -d demo_drivers/build ]; then
+            echo "Largest entries in demo_drivers/build:"
+            du -sk demo_drivers/build/* 2>/dev/null | sort -n | tail -30 | awk '{printf "%10.1f MiB  %s\n", $1 / 1024, $2}'
+          fi
         continue-on-error: true
 
       - name: Clean up after self-tests

--- a/README.md
+++ b/README.md
@@ -541,6 +541,30 @@ The `oomph_build.py` script is provided as a convenient one-stop solution for bu
 > [!IMPORTANT]
 > In addition to the standard requirements (CMake and Ninja, as described above), you will need a working Python 3 installation to run `oomph_build.py`. Ensure that `python3` is available in your `PATH`. If you plan to use the script's documentation-building feature (described below), make sure `doxygen` is installed as well.
 
+> [!NOTE]
+> By default, Ninja may run more build jobs than there are CPU cores. On some
+> systems this can cause the build to overwhelm the machine. The
+> `oomph_build.py` script therefore limits the build stage for the third-party
+> libraries, the main project, and the documentation to two fewer jobs than the
+> number of CPU cores by default.
+>
+> You can override this value with the `-j`/`--parallel` flag, or use all CPU
+> cores by passing `--use-max-jobs`. The `--use-max-jobs` flag cannot be
+> combined with `-j`/`--parallel`.
+>
+> If you are using raw CMake commands rather than `oomph_build.py`, and you are
+> not sure that your system can handle Ninja's default parallelism, set
+> `CMAKE_BUILD_PARALLEL_LEVEL` before running a Ninja build. For example, the
+> following command limits CMake build steps to two fewer jobs than the number
+> of CPU cores:
+>
+> ```bash
+> export CMAKE_BUILD_PARALLEL_LEVEL=$(python3 -c "import os; n=os.cpu_count() or 1; print(max(1, n - 2))")
+> ```
+>
+> You can increase this value if your machine can handle a more aggressive
+> build.
+
 ### Using the script
 
 To use the build script, `cd` to the top-level `oomph-lib` directory (the same directory that contains `oomph_build.py`) and run it with Python. For example:
@@ -567,6 +591,9 @@ python3 oomph_build.py --help
 Below is a list of the options and their purpose:
 
 - **`--build-doc`**: By default, the script does not build the documentation (to save time and space). If you want to generate the full HTML (and PDF) documentation for oomph-lib, include the `--build-doc` flag. This will build the documentation (using Doxygen and LaTeX) as part of the build process. *Note:* Building documentation can be time-consuming and requires Doxygen (and a LaTeX distribution for PDFs) to be installed. If these tools are missing, the doc build will fail – in that case, either install the necessary tools or omit this option.
+
+- **`-j`/`--parallel`**: Set the number of parallel build jobs used by the build stages. By default, this is two fewer than the number of CPU cores, with a lower limit of one.
+- **`--use-max-jobs`**: Use all available CPU cores for the build stages. This cannot be combined with `-j`/`--parallel`.
 
 - **`--oomph-CMAKE_INSTALL_PREFIX`**: Use this option when you intend to provide a custom installation location.
 - **`--oomph-OOMPH_ALLOW_INSTALL_AS_SUPERUSER`**: Use this option when you intend to install `oomph-lib` system-wide (by installing it in `/usr/local/`) using root privileges. This flag tells the script to configure the installation prefix to the system's default location (`/usr/local`) and to set any required internal CMake switches such as`OOMPH_ALLOW_INSTALL_AS_SUPERUSER=ON`. If you also specify `--oomph-CMAKE_INSTALL_PREFIX`, this flag will have no effect.)

--- a/README.md
+++ b/README.md
@@ -641,6 +641,16 @@ cd build_for_demo_drivers
 ctest -j4
 ```
 
+When running self-tests on a low-powered machine, there are two separate
+parallelism controls. `ctest -j` (or `CTEST_PARALLEL_LEVEL`) controls how many
+tests CTest runs at the same time. `CMAKE_BUILD_PARALLEL_LEVEL` controls how
+many compile or link jobs CMake may start when a test has to build one or more
+driver executables before running. For example:
+
+```bash
+CMAKE_BUILD_PARALLEL_LEVEL=2 CTEST_PARALLEL_LEVEL=1 ctest
+```
+
 While `ctest` is running, we provide an overview of the progress and document the run-times of individual tests. Finally, a summary of the passed/failed tests is provided.
 
 Note that running the tests creates a large amount of data, so once all the tests have completed (successfully!) you can delete the build directory:

--- a/cmake/OomphAddPureCppTest.cmake
+++ b/cmake/OomphAddPureCppTest.cmake
@@ -188,13 +188,15 @@ function(oomph_add_pure_cpp_test)
 
   # Create the test to be run by CTest. When we run the test, it will call
   # 'cmake --build ... --target check_...' which will call the check_... target
-  # defined above. Using cmake --build instead of calling the native build tool
-  # directly allows CMAKE_BUILD_PARALLEL_LEVEL to limit any compilation
-  # triggered while running tests.
+  # defined above. We pin the inner build to a single job because parallelism
+  # belongs at the ctest level (ctest -j N runs N tests concurrently); without
+  # this, each of those N tests would spawn its own full-core sub-build and
+  # over-subscribe the machine. In the common case the inner build is a no-op
+  # because the main build has already produced everything it needs.
   add_test(
     NAME ${TEST_NAME}
     COMMAND ${CMAKE_COMMAND} --build "${CMAKE_BINARY_DIR}" --target
-            check_${TEST_NAME}_${PATH_HASH}
+            check_${TEST_NAME}_${PATH_HASH} --parallel 1
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
 endfunction()
 # ------------------------------------------------------------------------------

--- a/cmake/OomphAddPureCppTest.cmake
+++ b/cmake/OomphAddPureCppTest.cmake
@@ -152,18 +152,15 @@ function(oomph_add_pure_cpp_test)
     VERBATIM)
   # ----------------------------------------------------------------------------
 
-  # Create the test to be run by CTest. When we run the test, it will call, e.g.
-  # 'ninja check_...' which will call the 'check_...' target defined above. As
-  # this target depends on the copy_... and build_targets_... targets, they will
-  # be called first, resulting in the required test files to be symlinked or
-  # copied to the build directory, and the targets the test depends on to get
-  # built. Once the data is in place and the executables have been built, the
-  # check_... commands will run, which will cause the individual executables to
-  # be run. Finally, the output validation.log file will be appended to the
-  # global validation.log file in the oomph-lib root directory.
+  # Create the test to be run by CTest. When we run the test, it will call
+  # 'cmake --build ... --target check_...' which will call the check_... target
+  # defined above. Using cmake --build instead of calling the native build tool
+  # directly allows CMAKE_BUILD_PARALLEL_LEVEL to limit any compilation
+  # triggered while running tests.
   add_test(
     NAME ${TEST_NAME}
-    COMMAND ${CMAKE_MAKE_PROGRAM} check_${TEST_NAME}_${PATH_HASH}
+    COMMAND ${CMAKE_COMMAND} --build "${CMAKE_BINARY_DIR}" --target
+            check_${TEST_NAME}_${PATH_HASH}
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
 endfunction()
 # ------------------------------------------------------------------------------

--- a/cmake/OomphAddPureCppTest.cmake
+++ b/cmake/OomphAddPureCppTest.cmake
@@ -129,23 +129,55 @@ function(oomph_add_pure_cpp_test)
   # ----------------------------------------------------------------------------
   # Run the dependencies to copy the test data, build the (sub)project(s)
   # targets, run all of the dependent targets then append the validation.log
-  # output to the global one.. The VERBATIM argument is necessary here to ensure
-  # that the "mpirun ..." commands are correctly escaped
+  # output to the global one.
   set(RUN_COMMAND ${RUN_WITH} ./${DEPENDS_ON} ${TEST_ARGS})
   list(JOIN RUN_COMMAND " " RUN_COMMAND)
+  set(TEST_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/run_test_${TEST_NAME}.sh")
+
+  # cmake-format: off
+  file(WRITE "${TEST_SCRIPT}" "#!/bin/bash\n\n")
+
+  file(APPEND "${TEST_SCRIPT}" "# Entering directory where this bash script lives\n")
+  file(APPEND "${TEST_SCRIPT}" "DIR=\"$(cd \"$(dirname \"\$\{BASH_SOURCE\[0\]\}\")\" && pwd)\"\n")
+  file(APPEND "${TEST_SCRIPT}" "cd \"\$\{DIR\}\"\n\n")
+
+  file(APPEND "${TEST_SCRIPT}" "# Run the validation command\n")
+  file(APPEND "${TEST_SCRIPT}" "${RUN_COMMAND}\n\n")
+
+  file(APPEND "${TEST_SCRIPT}" "# Store the exit code\n")
+  file(APPEND "${TEST_SCRIPT}" "EXIT_CODE=$?\n\n")
+
+  file(APPEND "${TEST_SCRIPT}" "# Define validation-log paths\n")
+  file(APPEND "${TEST_SCRIPT}" "VALIDATION_DIR=\"${CMAKE_CURRENT_BINARY_DIR}/Validation\"\n")
+  file(APPEND "${TEST_SCRIPT}" "VALIDATION_LOG=\"${CMAKE_CURRENT_BINARY_DIR}/Validation/${LOG_FILE}\"\n")
+  file(APPEND "${TEST_SCRIPT}" "GLOBAL_VALIDATION_LOG=\"${CMAKE_BINARY_DIR}/validation.log\"\n\n")
+
+  file(APPEND "${TEST_SCRIPT}" "# Append the validation log file to the 'global' log file\n")
+  file(APPEND "${TEST_SCRIPT}" "if [ -e \"$VALIDATION_LOG\" ]; then\n")
+  file(APPEND "${TEST_SCRIPT}" "  cat \"$VALIDATION_LOG\" >> \"$GLOBAL_VALIDATION_LOG\" || exit 1\n")
+  file(APPEND "${TEST_SCRIPT}" "fi\n\n")
+
+  file(APPEND "${TEST_SCRIPT}" "# Stop here if we exited with a non-zero exit code\n")
+  file(APPEND "${TEST_SCRIPT}" "if [ $EXIT_CODE -ne 0 ]; then\n  echo \"Test stopped with exit code $EXIT_CODE!\"\n  exit $EXIT_CODE\nfi\n\n")
+
+  file(APPEND "${TEST_SCRIPT}" "# Stop here if there's no validation log file\n")
+  file(APPEND "${TEST_SCRIPT}" "if [ ! -e \"$VALIDATION_LOG\" ]; then\n")
+  file(APPEND "${TEST_SCRIPT}" "  printf '\\n%s:\\n\\t%s\\n%s\\n' 'Unable to locate validation log file:' \"$VALIDATION_LOG\" 'Stopping here...'\n")
+  file(APPEND "${TEST_SCRIPT}" "  exit 1\n")
+  file(APPEND "${TEST_SCRIPT}" "fi\n\n")
+
+  file(APPEND "${TEST_SCRIPT}" "# Optionally remove successful validation output to save disk space\n")
+  file(APPEND "${TEST_SCRIPT}" "if [ \"$OOMPH_DELETE_VALIDATION_DIRECTORY_AFTER_SUCCESSFUL_TEST\" = \"yes\" ]; then\n")
+  file(APPEND "${TEST_SCRIPT}" "  printf '\\n%s\\n\\t%s\\n' 'Deleting successful Validation directory to save disk space:' \"$VALIDATION_DIR\" >> \"$GLOBAL_VALIDATION_LOG\"\n")
+  file(APPEND "${TEST_SCRIPT}" "  rm -rf \"$VALIDATION_DIR\"\n")
+  file(APPEND "${TEST_SCRIPT}" "fi\n")
+
+  file(CHMOD "${TEST_SCRIPT}" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+  # cmake-format: on
+
   add_custom_target(
     check_${TEST_NAME}_${PATH_HASH}
-    # Run the executable
-    COMMAND ${BASH_PROGRAM} -c ${RUN_COMMAND}
-    # Check for the validation.log file
-    COMMAND
-      ${BASH_PROGRAM} -c
-      "test -e \"${CMAKE_CURRENT_BINARY_DIR}/Validation/${LOG_FILE}\" || ( \
-          printf \"\\nUnable to locate file:\\n\\n\\t${CMAKE_CURRENT_BINARY_DIR}/Validation/${LOG_FILE}\\n\\nStopping here...\\n\\n\" && \
-          exit 1 )"
-    # Append validation.log to top-level validation.log
-    COMMAND cat "${CMAKE_CURRENT_BINARY_DIR}/Validation/${LOG_FILE}" >>
-            "${CMAKE_BINARY_DIR}/validation.log"
+    COMMAND "${TEST_SCRIPT}"
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     DEPENDS ${DEPENDS_ON}_${PATH_HASH} copy_${PATH_HASH}
             clean_validation_dir_${PATH_HASH}

--- a/cmake/OomphAddPureCppTest.cmake
+++ b/cmake/OomphAddPureCppTest.cmake
@@ -136,6 +136,8 @@ function(oomph_add_pure_cpp_test)
 
   # cmake-format: off
   file(WRITE "${TEST_SCRIPT}" "#!/bin/bash\n\n")
+  file(APPEND "${TEST_SCRIPT}" "# auto-generated script (created by cmake/OomphAddPureCppTest.cmake)\n")
+  file(APPEND "${TEST_SCRIPT}" "# Do not edit!\n\n")
 
   file(APPEND "${TEST_SCRIPT}" "# Entering directory where this bash script lives\n")
   file(APPEND "${TEST_SCRIPT}" "DIR=\"$(cd \"$(dirname \"\$\{BASH_SOURCE\[0\]\}\")\" && pwd)\"\n")

--- a/cmake/OomphAddTest.cmake
+++ b/cmake/OomphAddTest.cmake
@@ -248,20 +248,36 @@ function(oomph_add_test)
   file(APPEND "${TEST_SCRIPT}" "# Jump back to the original calling directory\n")
   file(APPEND "${TEST_SCRIPT}" "cd - > /dev/null\n\n")
 
+  # Define paths used by the post-test handling below
+  file(APPEND "${TEST_SCRIPT}" "# Define validation-log paths\n")
+  file(APPEND "${TEST_SCRIPT}" "VALIDATION_DIR=\"${CMAKE_CURRENT_BINARY_DIR}/Validation\"\n")
+  file(APPEND "${TEST_SCRIPT}" "VALIDATION_LOG=\"${CMAKE_CURRENT_BINARY_DIR}/Validation/validation.log\"\n")
+  file(APPEND "${TEST_SCRIPT}" "GLOBAL_VALIDATION_LOG=\"${CMAKE_BINARY_DIR}/validation.log\"\n\n")
+
+  # Append validation.log to top-level validation.log whenever it exists, even
+  # if the validation command failed.
+  file(APPEND "${TEST_SCRIPT}" "# Append the validation log file to the 'global' log file\n")
+  file(APPEND "${TEST_SCRIPT}" "if [ -e \"$VALIDATION_LOG\" ]; then\n")
+  file(APPEND "${TEST_SCRIPT}" "  cat \"$VALIDATION_LOG\" >> \"$GLOBAL_VALIDATION_LOG\" || exit 1\n")
+  file(APPEND "${TEST_SCRIPT}" "fi\n\n")
+
   # Now exit if nonzero
   file(APPEND "${TEST_SCRIPT}" "# Stop here if we exited with a non-zero exit code\n")
   file(APPEND "${TEST_SCRIPT}" "if [ $EXIT_CODE -ne 0 ]; then\n  echo \"Test stopped with exit code $EXIT_CODE!\"\n  exit $EXIT_CODE\nfi\n\n")
 
   # Check for the validation.log file
   file(APPEND "${TEST_SCRIPT}" "# Stop here if there's no validation log file\n")
-  file(APPEND "${TEST_SCRIPT}" "if [ ! -e \"${CMAKE_CURRENT_BINARY_DIR}/Validation/validation.log\" ]; then\n")
-  file(APPEND "${TEST_SCRIPT}" "  printf '\\n%s:\\n\\t%s\\n%s\\n' 'Unable to locate validation log file:' '\"${CMAKE_CURRENT_BINARY_DIR}/Validation/validation.log\"' 'Stopping here...'\n")
+  file(APPEND "${TEST_SCRIPT}" "if [ ! -e \"$VALIDATION_LOG\" ]; then\n")
+  file(APPEND "${TEST_SCRIPT}" "  printf '\\n%s:\\n\\t%s\\n%s\\n' 'Unable to locate validation log file:' \"$VALIDATION_LOG\" 'Stopping here...'\n")
   file(APPEND "${TEST_SCRIPT}" "  exit 1\n")
   file(APPEND "${TEST_SCRIPT}" "fi\n\n")
 
-  # Append validation.log to top-level validation.log
-  file(APPEND "${TEST_SCRIPT}" "# Append the validation log file to the 'global' log file\n")
-  file(APPEND "${TEST_SCRIPT}" "cat \"${CMAKE_CURRENT_BINARY_DIR}/Validation/validation.log\" >> \"${CMAKE_BINARY_DIR}/validation.log\"\n")
+  # Optionally delete the Validation/ directory after successful tests.
+  file(APPEND "${TEST_SCRIPT}" "# Optionally remove successful validation output to save disk space\n")
+  file(APPEND "${TEST_SCRIPT}" "if [ \"$OOMPH_DELETE_VALIDATION_DIRECTORY_AFTER_SUCCESSFUL_TEST\" = \"yes\" ]; then\n")
+  file(APPEND "${TEST_SCRIPT}" "  printf '\\n%s\\n\\t%s\\n' 'Deleting successful Validation directory to save disk space:' \"$VALIDATION_DIR\" >> \"$GLOBAL_VALIDATION_LOG\"\n")
+  file(APPEND "${TEST_SCRIPT}" "  rm -rf \"$VALIDATION_DIR\"\n")
+  file(APPEND "${TEST_SCRIPT}" "fi\n")
 
   # Make the script executable
   file(CHMOD "${TEST_SCRIPT}" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)

--- a/cmake/OomphAddTest.cmake
+++ b/cmake/OomphAddTest.cmake
@@ -286,18 +286,15 @@ function(oomph_add_test)
   add_dependencies(${TEST_NAME} copy_${PATH_HASH} build_targets_${PATH_HASH}
                    clean_validation_dir_${PATH_HASH})
 
-  # Create the test to be run by CTest. When we run the test, it will call, e.g.
-  # 'ninja check_...' which will call the 'check_...' target defined above. As
-  # this target depends on the copy_... and build_targets_... targets, they will
-  # be called first, resulting in the required test files to be symlinked or
-  # copied to the build directory, and the targets the test depends on to get
-  # built. Once the data is in place and the executables have been built, the
-  # check_... commands will run, which will cause the validate.sh script or
-  # individual executables to be run. Finally, the test validation.log file will
-  # be appended to the root build directory validation.log file.
+  # Create the test to be run by CTest. When we run the test, it will call
+  # 'cmake --build ... --target check_...' which will call the check_... target
+  # defined above. Using cmake --build instead of calling the native build tool
+  # directly allows CMAKE_BUILD_PARALLEL_LEVEL to limit any compilation
+  # triggered while running tests.
   add_test(
     NAME ${TEST_NAME}
-    COMMAND ${CMAKE_MAKE_PROGRAM} check_${PATH_HASH}
+    COMMAND ${CMAKE_COMMAND} --build "${CMAKE_BINARY_DIR}" --target
+            check_${PATH_HASH}
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
 endfunction()
 # ------------------------------------------------------------------------------

--- a/cmake/OomphAddTest.cmake
+++ b/cmake/OomphAddTest.cmake
@@ -306,13 +306,15 @@ function(oomph_add_test)
 
   # Create the test to be run by CTest. When we run the test, it will call
   # 'cmake --build ... --target check_...' which will call the check_... target
-  # defined above. Using cmake --build instead of calling the native build tool
-  # directly allows CMAKE_BUILD_PARALLEL_LEVEL to limit any compilation
-  # triggered while running tests.
+  # defined above. We pin the inner build to a single job because parallelism
+  # belongs at the ctest level (ctest -j N runs N tests concurrently); without
+  # this, each of those N tests would spawn its own full-core sub-build and
+  # over-subscribe the machine. In the common case the inner build is a no-op
+  # because the main build has already produced everything it needs.
   add_test(
     NAME ${TEST_NAME}
     COMMAND ${CMAKE_COMMAND} --build "${CMAKE_BINARY_DIR}" --target
-            check_${PATH_HASH}
+            check_${PATH_HASH} --parallel 1
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
 endfunction()
 # ------------------------------------------------------------------------------

--- a/cmake/OomphAddTest.cmake
+++ b/cmake/OomphAddTest.cmake
@@ -229,6 +229,8 @@ function(oomph_add_test)
 
   # The shebang
   file(WRITE "${TEST_SCRIPT}" "#!/bin/bash\n\n")
+  file(APPEND "${TEST_SCRIPT}" "# auto-generated script (created by cmake/OomphAddTest.cmake)\n")
+  file(APPEND "${TEST_SCRIPT}" "# Do not edit!\n\n")
 
   # Jump to the directory of the script
   file(APPEND "${TEST_SCRIPT}" "# Entering directory where this bash script lives\n")

--- a/external_distributions/CMakeLists.txt
+++ b/external_distributions/CMakeLists.txt
@@ -130,8 +130,12 @@ include(OomphGetExternalProjectHelper)
 
 # --------------------------------[ GENERAL ]----------------------------------
 
-# Decide on number of jobs to use for building projects
-ProcessorCount(OOMPH_NUM_JOBS)
+# Decide on number of jobs to use for building projects. If the caller passed
+# OOMPH_NUM_JOBS in via the CMake cache (e.g. via oomph_build.py's -j flag),
+# honour it; otherwise fall back to the detected CPU count.
+if(NOT DEFINED OOMPH_NUM_JOBS OR OOMPH_NUM_JOBS STREQUAL "")
+  ProcessorCount(OOMPH_NUM_JOBS)
+endif()
 if(OOMPH_NUM_JOBS EQUAL 0)
   set(OOMPH_NUM_JOBS 1)
   message(WARNING "Could not determine CPU cores. Using single job.")

--- a/oomph_build.py
+++ b/oomph_build.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import sys
 import time
-from argparse import BooleanOptionalAction, Namespace, ArgumentParser
+from argparse import ArgumentTypeError, BooleanOptionalAction, Namespace, ArgumentParser
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -108,12 +108,6 @@ def write_presets_file(presets_dict: dict, json_path: Path):
         json.dump(presets_dict, f, indent=2)
 
 
-def get_extra_build_args(args: Namespace) -> list[str]:
-    if args.generator == "Ninja":
-        return []
-    return ["-j", str(os.cpu_count() or 1)]
-
-
 def generate_external_dist_preset(
     external_dist_build_dir: Path,
     ext_cache: dict,
@@ -182,6 +176,7 @@ def configure_build_and_install_external_libs(
     args: Namespace,
     external_dist_dir: Path,
     external_dist_build_dir: Path,
+    num_jobs: int,
     verbose: bool,
 ):
     """
@@ -205,6 +200,9 @@ def configure_build_and_install_external_libs(
 
     # Specify the build type; 'args.config' will always be set
     ext_cache["CMAKE_BUILD_TYPE"] = args.config
+
+    # Certain TPLs have their build parallel level specified with OOMPH_NUM_JOBS.
+    ext_cache["OOMPH_NUM_JOBS"] = str(num_jobs)
 
     # Do we need to add 'ccache' support?
     if args.enable_ccache:
@@ -236,8 +234,7 @@ def configure_build_and_install_external_libs(
     # Build and install external
     print_progress(
         ">>> Building and installing third-party libraries", pad_to=60, end=line_end)
-    extra_build_args = get_extra_build_args(args)
-    build_cmd = ["cmake", "--build", "--preset", "tpl"] + extra_build_args
+    build_cmd = ["cmake", "--build", "--preset", "tpl", "--parallel", str(num_jobs)]
     start_time = time.perf_counter()
     run_command(build_cmd, external_dist_dir, verbose)
     time_elapsed = time.perf_counter() - start_time
@@ -249,6 +246,7 @@ def configure_build_and_install_oomph(
     oomph_dir: Path,
     oomph_build_dir: Path,
     ext_flags: dict,
+    num_jobs: int,
     verbose: bool
 ):
     """
@@ -307,8 +305,10 @@ def configure_build_and_install_oomph(
 
     # Build and install in one go
     print_progress(">>> Building and installing main project", pad_to=60, end=line_end)
-    extra_build_args = get_extra_build_args(args)
-    build_cmd = ["cmake", "--build", "--preset", "main", "--target", "install"] + extra_build_args
+    build_cmd = [
+        "cmake", "--build", "--preset", "main",
+        "--target", "install", "--parallel", str(num_jobs),
+    ]
     start_time = time.perf_counter()
     run_command(build_cmd, oomph_dir, verbose)
     time_elapsed = time.perf_counter() - start_time
@@ -318,6 +318,7 @@ def configure_build_and_install_oomph(
 def configure_build_doc(
     args: Namespace,
     doc_dir: Path,
+    num_jobs: int,
     verbose: bool,
 ):
     """
@@ -333,8 +334,7 @@ def configure_build_doc(
 
     # Build
     print_progress(">>> Building", pad_to=60, end="\n" if verbose else "")
-    extra_build_args = get_extra_build_args(args)
-    build_cmd = ["cmake", "--build", "build"] + extra_build_args
+    build_cmd = ["cmake", "--build", "build", "--parallel", str(num_jobs)]
     start_time = time.perf_counter()
     run_command(build_cmd, doc_dir, verbose)
     time_elapsed = time.perf_counter() - start_time
@@ -427,6 +427,21 @@ def parse_args():
     in, e.g. '--enable-ccache' --> 'args.enable_ccache'.
     """
 
+    def get_max_jobs_allowed():
+        return os.cpu_count() or 1
+
+    def get_default_parallel_level():
+        return max(1, get_max_jobs_allowed() - 2)
+
+    def positive_int(value):
+        try:
+            parsed_value = int(value)
+        except ValueError:
+            raise ArgumentTypeError("must be an integer") from None
+        if parsed_value < 1:
+            raise ArgumentTypeError("must be at least 1")
+        return parsed_value
+
     def expanded_path(p):
         if p is None:
             return
@@ -464,6 +479,9 @@ def parse_args():
     general_group.add_argument("-c", "--config", default="Release", choices=["Debug", "Release", "RelWithDebInfo", "MinSizeRel"], help="Specify CMAKE_BUILD_TYPE (default: Release) for both external and oomph-lib.")
     general_group.add_argument("-g", "--generator", default="Ninja", help="CMake generator to use. For example, 'Unix Makefiles' or 'Ninja' (default: Ninja).")
     general_group.add_argument(      "--enable-ccache", action="store_true", help="Enable use of 'ccache' for compilation.")
+    general_group_mutex = general_group.add_mutually_exclusive_group(required=False)
+    general_group_mutex.add_argument("-j", "--parallel", type=positive_int, default=get_default_parallel_level(), metavar="N", help=f"The number of jobs to build in parallel with (default: {get_default_parallel_level()}).")
+    general_group_mutex.add_argument("--use-max-jobs", action="store_true", help=f"Use the maximum number of jobs to build in parallel (i.e. {get_max_jobs_allowed()}). Cannot be combined with the -j/--parallel flag.")
 
     # Flags common to both external_distributions and the oomph-lib project
     common_group = parser.add_argument_group("common build flags")
@@ -513,6 +531,9 @@ def parse_args():
 
     # Parse the flags
     args = parser.parse_args()
+
+    if args.use_max_jobs:
+        args.parallel = get_max_jobs_allowed()
 
     # Handy sanity checks
     if (args.oomph_OOMPH_ENABLE_PARANOID == "ON") or (args.oomph_OOMPH_ENABLE_RANGE_CHECKING == "ON"):
@@ -641,7 +662,7 @@ if __name__ == "__main__":
     # Configure, build and install external libraries, retrieving the JSON file path
     if args.build_tpl:
         configure_build_and_install_external_libs(
-            args, external_dist_dir, external_dist_build_dir, args.verbose)
+            args, external_dist_dir, external_dist_build_dir, args.parallel, args.verbose)
     else:
         print_progress(">>> Skipping build of third-party libraries")
 
@@ -662,13 +683,13 @@ if __name__ == "__main__":
         ext_flags = read_external_json_file(external_dist_json_path)
 
         configure_build_and_install_oomph(
-            args, project_root, oomph_build_dir, ext_flags, args.verbose)
+            args, project_root, oomph_build_dir, ext_flags, args.parallel, args.verbose)
     else:
         print_progress(">>> Skipping build of oomph-lib project")
 
     # Configure and build the docs
     if args.build_doc:
-        configure_build_doc(args, doc_dir, args.verbose)
+        configure_build_doc(args, doc_dir, args.parallel, args.verbose)
     else:
         print_progress(">>> Skipping build of docs")
 


### PR DESCRIPTION
Aims to address https://github.com/oomph-lib/oomph-lib/issues/227.